### PR TITLE
ci(workflows): move hashFiles() from job-level if to step-level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: quality
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('Dockerfile') != ''
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: build-main
       cancel-in-progress: false
@@ -90,6 +90,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build & push
+        if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary
hashFiles() is only valid in step-level `if:` conditions. The job-level use introduced in e52c671 caused the workflow YAML to fail validation, producing "0s, 0 jobs" runs on every push since. This PR restores the pre-e52c671 shape: gate the `build` job on `event_name + ref` only, and gate the docker `Build & push` step on `hashFiles('Dockerfile')`.

## Related issue
Closes colophon-group/murmur#37

## Files changed (high-level)
- `.github/workflows/ci.yml` — drop `&& hashFiles('Dockerfile') != ''` from job-level `if:`; add `if: hashFiles('Dockerfile') != ''` to the `Build & push` step.

## Verification (from the issue)
- [x] Workflow YAML validates: this PR's `pull_request` event produced run `25101174700` with actual jobs (not "0s, 0 jobs").
- [x] `quality` job ran and concluded `success`.
- [x] `build` job concluded `skipped` (correctly — `pull_request` event, not `push` to main).
- [x] Diff is the minimal 4-line move described in the issue.

## Manual checks run locally
- `bash scripts/grep-all.sh` — All grep gates passed.
- `pnpm typecheck/lint/test/build` — N/A (M1 not landed yet).

## Proof of fix
`gh run list --repo colophon-group/murmur --branch dev/37-ci-hashfiles-fix --limit 1`:
```
completed	success	ci(workflows): move hashFiles() from job-level if to step-level	.github/workflows/ci.yml	dev/37-ci-hashfiles-fix	pull_request	25101174700	15s	2026-04-29T09:27:44Z
```

`gh run view 25101174700 --json jobs --jq '.jobs[] | {name, conclusion}'`:
```
{"name":"quality","conclusion":"success"}
{"name":"build","conclusion":"skipped"}
```

Run URL: https://github.com/colophon-group/murmur/actions/runs/25101174700

## Notes for reviewer
- The PR is a 4-line diff inside `.github/workflows/ci.yml` and touches nothing else (per orchestrator's scope guidance).
- Earlier steps in the `build` job (checkout, buildx setup, GHCR login) still run on every push to main even when no Dockerfile exists — this matches the pre-e52c671 workflow and is out of scope for this fix.