### PR TITLE
feat(dispatch): Ajv-based JSON Schema validation utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "grep-no-token-logged": "bash scripts/grep-no-secrets-logged.sh"
   },
   "dependencies": {
-    "@murmur/contracts-types": "workspace:*"
+    "@murmur/contracts-types": "workspace:*",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@murmur/contracts-types':
         specifier: workspace:*
         version: link:packages/contracts-types
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
@@ -734,8 +740,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -942,6 +959,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1075,6 +1095,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1229,6 +1252,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1980,12 +2007,23 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2234,6 +2272,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -2358,6 +2398,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2491,6 +2533,8 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/dispatch/validation.test.ts
+++ b/src/dispatch/validation.test.ts
@@ -277,6 +277,39 @@ describe("validateAgainst (runtime instance validation)", () => {
     expect(bad.ok).toBe(false);
   });
 
+  it("rejects validateAgainst when called with a non-object schema (defensive)", () => {
+    const r1 = validateAgainst(null, { x: 1 });
+    expect(r1.ok).toBe(false);
+    if (!r1.ok) {
+      expect(r1.errors[0]).toContain("validation::schema must be a JSON object");
+    }
+    const r2 = validateAgainst([1, 2, 3], { x: 1 });
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) {
+      expect(r2.errors[0]).toContain("validation::schema must be a JSON object");
+      expect(r2.errors[0]).toContain("array");
+    }
+    const r3 = validateAgainst("string-not-schema", { x: 1 });
+    expect(r3.ok).toBe(false);
+    if (!r3.ok) {
+      expect(r3.errors[0]).toContain("string");
+    }
+  });
+
+  it("returns the compile error if validateAgainst is called with an uncompilable schema (should not happen in prod)", () => {
+    // `$ref` to a non-existent definition fails to compile even at the
+    // tolerant runtime instance.
+    const broken = {
+      type: "object",
+      properties: { x: { $ref: "#/$defs/Nope" } },
+    };
+    const r = validateAgainst(broken, { x: 1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors[0]).toMatch(/^validation::/);
+    }
+  });
+
   it("does NOT use the strict registration validator at runtime — unknown keyword logs but does not fail", () => {
     // Runtime Ajv is `strict: 'log'`. A schema with a harmless unknown
     // keyword (e.g. an OpenAPI extension like `x-internal`) should still

--- a/src/dispatch/validation.test.ts
+++ b/src/dispatch/validation.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for `src/dispatch/validation.ts`.
+ *
+ * Test bullets are taken verbatim from issue #14's "Verification"
+ * section. Every named bullet has at least one corresponding `it()`
+ * below; the bullet text is included in the test title so a reviewer
+ * can grep for it.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  validateJsonSchema,
+  validateAgainst,
+  formatAjvError,
+} from "./validation.js";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const allSeven = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "../../docs/contracts/fixtures/all-seven.json"),
+    "utf8",
+  ),
+) as Record<string, unknown>;
+
+// The §3.1 jobseek pipeline def. We exercise the schemas inside it,
+// not the pipeline-def envelope itself (which has its own schema in
+// docs/contracts/pipeline-def.schema.json).
+const PIPELINE_DEF = allSeven["1_pipeline_def"] as {
+  initial_input: object;
+  subtasks: ReadonlyArray<{
+    id: string;
+    output_schema: object;
+    subcommands?: ReadonlyArray<{ name: string; input_schema?: object }>;
+  }>;
+};
+
+describe("validateJsonSchema (registration-time)", () => {
+  it("accepts a valid JSON Schema (no error)", () => {
+    const result = validateJsonSchema({
+      type: "object",
+      properties: { foo: { type: "string" } },
+      required: ["foo"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a schema with an unknown keyword (would be 400 at registration)", () => {
+    // `requried` (typo of `required`) is not a JSON Schema keyword.
+    // Ajv `strict: true` rejects it at compile time.
+    const result = validateJsonSchema({
+      type: "object",
+      requried: ["foo"], // typo
+      properties: { foo: { type: "string" } },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/requried|strict/i);
+    }
+  });
+
+  it("rejects a schema referencing an undefined $ref (would be 400)", () => {
+    const result = validateJsonSchema({
+      type: "object",
+      properties: { foo: { $ref: "#/$defs/DoesNotExist" } },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects non-object inputs (e.g. a bare boolean)", () => {
+    expect(validateJsonSchema(true).ok).toBe(false);
+    expect(validateJsonSchema(null).ok).toBe(false);
+    expect(validateJsonSchema("not a schema").ok).toBe(false);
+  });
+
+  it("registers the §3.1 jobseek pipeline def YAML without error (initial_input + every subtask schema)", () => {
+    expect(validateJsonSchema(PIPELINE_DEF.initial_input).ok).toBe(true);
+    for (const subtask of PIPELINE_DEF.subtasks) {
+      const r = validateJsonSchema(subtask.output_schema);
+      expect(
+        r.ok,
+        `subtask ${subtask.id} output_schema: ${r.ok ? "" : r.error}`,
+      ).toBe(true);
+      for (const sub of subtask.subcommands ?? []) {
+        if (sub.input_schema !== undefined) {
+          const ri = validateJsonSchema(sub.input_schema);
+          expect(
+            ri.ok,
+            `subtask ${subtask.id} subcommand ${sub.name} input_schema: ${ri.ok ? "" : ri.error}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("rejects a deliberately broken version of the §3.1 YAML (unknown keyword injected)", () => {
+    const broken = {
+      ...PIPELINE_DEF.initial_input,
+      // `addtionalProperties` (typo) is not a known keyword; strict mode
+      // rejects it.
+      addtionalProperties: false,
+    } as object;
+    expect(validateJsonSchema(broken).ok).toBe(false);
+  });
+});
+
+describe("validateAgainst (runtime instance validation)", () => {
+  // Output schema cribbed from §3.1 `pre-verify` subtask:
+  const PRE_VERIFY_OUTPUT_SCHEMA = {
+    type: "object",
+    required: ["verified", "canonical_name", "canonical_website"],
+    properties: {
+      verified: { type: "boolean" },
+      canonical_name: { type: "string" },
+      canonical_website: { type: "string" },
+      reject_reason: { type: "string" },
+    },
+  };
+
+  it("accepts a valid instance (no errors)", () => {
+    const result = validateAgainst(PRE_VERIFY_OUTPUT_SCHEMA, {
+      verified: true,
+      canonical_name: "ExampleCo",
+      canonical_website: "https://example.co",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        verified: true,
+        canonical_name: "ExampleCo",
+        canonical_website: "https://example.co",
+      });
+    }
+  });
+
+  it("accepts submit_result with an extra unknown field (no additionalProperties: false)", () => {
+    const result = validateAgainst(PRE_VERIFY_OUTPUT_SCHEMA, {
+      verified: true,
+      canonical_name: "ExampleCo",
+      canonical_website: "https://example.co",
+      surprise: "this should be tolerated",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects submit_result with a type mismatch — 'validation:/board_url:must be string'", () => {
+    const schema = {
+      type: "object",
+      required: ["board_url"],
+      properties: { board_url: { type: "string" } },
+    };
+    const result = validateAgainst(schema, { board_url: 123 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("validation:/board_url:must be string");
+    }
+  });
+
+  it("rejects submit_result with a missing required field — 'validation::must have required property \\'verified\\''", () => {
+    const result = validateAgainst(PRE_VERIFY_OUTPUT_SCHEMA, {
+      canonical_name: "ExampleCo",
+      canonical_website: "https://example.co",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain(
+        "validation::must have required property 'verified'",
+      );
+    }
+  });
+
+  it("rejects task_tool with bad args — pattern mismatch yields 'validation:/board_url:must match pattern …'", () => {
+    const inputSchema = {
+      type: "object",
+      required: ["board_url"],
+      properties: {
+        board_url: { type: "string", pattern: "^https://" },
+      },
+    };
+    const result = validateAgainst(inputSchema, {
+      board_url: "ftp://nope.example.com",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Ajv's message is `must match pattern "<pattern>"`.
+      expect(
+        result.errors.some(
+          (e) =>
+            e.startsWith("validation:/board_url:") && e.includes("must match pattern"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("returns multiple errors all together (not first-only)", () => {
+    const schema = {
+      type: "object",
+      required: ["a", "b", "c"],
+      properties: {
+        a: { type: "string" },
+        b: { type: "string" },
+        c: { type: "string" },
+      },
+    };
+    // Missing all three required fields:
+    const result = validateAgainst(schema, {});
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // All three required-property errors must appear.
+      expect(
+        result.errors.some((e) =>
+          e.includes("must have required property 'a'"),
+        ),
+      ).toBe(true);
+      expect(
+        result.errors.some((e) =>
+          e.includes("must have required property 'b'"),
+        ),
+      ).toBe(true);
+      expect(
+        result.errors.some((e) =>
+          e.includes("must have required property 'c'"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("formats every error with a JSON-Pointer path (root → empty, nested → '/foo/0/bar')", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["bar"],
+            properties: { bar: { type: "string" } },
+          },
+        },
+      },
+    };
+    const result = validateAgainst(schema, {
+      items: [{ bar: 1 }, { /* missing bar */ }],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some((e) => e.startsWith("validation:/items/0/bar:")),
+      ).toBe(true);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.startsWith("validation:/items/1:") &&
+            e.includes("must have required property 'bar'"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("caches compiled validators by schema reference (idempotent fast path)", () => {
+    const schema = { type: "string" };
+    // First call compiles, second call reuses. We cannot directly observe
+    // the cache, but we can assert correctness across many calls without
+    // throwing or slowing down meaningfully.
+    for (let i = 0; i < 100; i++) {
+      const r = validateAgainst(schema, "ok");
+      expect(r.ok).toBe(true);
+    }
+    const bad = validateAgainst(schema, 42);
+    expect(bad.ok).toBe(false);
+  });
+
+  it("does NOT use the strict registration validator at runtime — unknown keyword logs but does not fail", () => {
+    // Runtime Ajv is `strict: 'log'`. A schema with a harmless unknown
+    // keyword (e.g. an OpenAPI extension like `x-internal`) should still
+    // validate the instance.
+    const schema = {
+      type: "object",
+      "x-internal": "some annotation",
+      properties: { foo: { type: "string" } },
+    };
+    const result = validateAgainst(schema, { foo: "ok" });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("formatAjvError (internal)", () => {
+  it("formats a root error with empty path: 'validation::<msg>'", () => {
+    expect(
+      formatAjvError({
+        instancePath: "",
+        schemaPath: "#/required",
+        keyword: "required",
+        params: { missingProperty: "verified" },
+        message: "must have required property 'verified'",
+      }),
+    ).toBe("validation::must have required property 'verified'");
+  });
+
+  it("formats a nested error: 'validation:/foo/0/bar:<msg>'", () => {
+    expect(
+      formatAjvError({
+        instancePath: "/foo/0/bar",
+        schemaPath: "#/properties/foo/items/properties/bar/type",
+        keyword: "type",
+        params: { type: "string" },
+        message: "must be string",
+      }),
+    ).toBe("validation:/foo/0/bar:must be string");
+  });
+
+  it("uses an empty message when Ajv supplies none (defensive)", () => {
+    expect(
+      formatAjvError({
+        instancePath: "/x",
+        schemaPath: "#/x",
+        keyword: "type",
+        params: {},
+      }),
+    ).toBe("validation:/x:");
+  });
+});

--- a/src/dispatch/validation.ts
+++ b/src/dispatch/validation.ts
@@ -1,0 +1,147 @@
+/**
+ * JSON Schema validation utilities for the dispatch layer.
+ *
+ * These are pure utilities — they do NOT wire themselves into HTTP
+ * routes. The consumers are:
+ *   - `POST /pipelines` (M4 / #9): calls {@link validateJsonSchema}
+ *     against `inputs`, `outputs`, and each subcommand's
+ *     `input_schema` / `output_schema` to reject malformed pipeline
+ *     definitions at registration time.
+ *   - `submit_result` (M5 / #10): calls {@link validateAgainst} with
+ *     the active subtask's `output_schema` and the submitted result.
+ *   - `task_tool` dispatch (M7 / #12): calls {@link validateAgainst}
+ *     with the subcommand's `input_schema` and the request `args`.
+ *
+ * Two Ajv instances are used:
+ *   - `registrationAjv` — `strict: true`. Rejects unknown keywords and
+ *     unresolved `$ref`s. This is the right behavior for accepting
+ *     pipeline definitions from operators: a typo in `requried` (sic)
+ *     should be flagged at register-time, not silently ignored at
+ *     runtime. JSON Schema draft 2020-12 meta-schema is loaded by the
+ *     `Ajv2020` import.
+ *   - `runtimeAjv` — `strict: 'log'`. Validates instances against
+ *     already-accepted schemas; we do NOT want a forward-compatibility
+ *     unknown-keyword to fail a submission, so we downgrade to a log.
+ *
+ * Both instances share `allErrors: true` so a single validation call
+ * returns every offending path, not just the first.
+ *
+ * Error format for {@link validateAgainst} matches the M0 envelope's
+ * `Err.errors[]` string form: `validation:<json-pointer>:<message>`.
+ * The JSON Pointer is Ajv's `instancePath` (RFC 6901). When the error
+ * is at the document root, `instancePath` is the empty string, which
+ * yields `validation::<message>`. This is intentional — see the M0
+ * fixture in `docs/contracts/fixtures/all-seven.json` §5.
+ *
+ * Compiled validators are cached per schema-object identity using a
+ * `WeakMap<object, ValidateFunction>`. This matters: a hot dispatch
+ * loop validates the same schema thousands of times per run. Note the
+ * cache is keyed by reference, not by structural equality — callers
+ * are expected to hold their schemas stably (M4 stores them in the
+ * pipelines table, so this holds).
+ *
+ * @see DESIGN.md §3.1 — schema fields on subtasks/subcommands
+ * @see DESIGN.md §4.1 step 1 — schema validation at run start
+ * @see docs/contracts/fixtures/all-seven.json §5 — `validation_error_envelope`
+ */
+
+import Ajv2020, { type ValidateFunction, type ErrorObject } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+/**
+ * Result of registration-time JSON Schema shape validation.
+ *
+ * A successful result carries no payload — the caller already holds
+ * the schema. A failure carries a single human-readable `error`
+ * string of the form `<json-pointer>:<message>` so the route handler
+ * can return a 400 with the offending path.
+ */
+export type ValidateSchemaResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string };
+
+/**
+ * Result of runtime instance validation.
+ *
+ * On success, `value` is the (untouched) instance, narrowed to `T`.
+ * On failure, `errors` is a non-empty array of strings, each formatted
+ * as `validation:<json-pointer>:<message>`. Multiple errors are all
+ * returned (Ajv configured with `allErrors: true`).
+ */
+export type ValidateAgainstResult<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly errors: ReadonlyArray<string> };
+
+/**
+ * Validate that the given value is a structurally valid JSON Schema
+ * (draft 2020-12). Used by `POST /pipelines` to reject malformed
+ * pipeline definitions before they enter the run loop.
+ *
+ * Specifically, this:
+ *   - rejects schemas containing unknown keywords (Ajv `strict: true`),
+ *   - rejects schemas with unresolved `$ref`s (compile-time failure),
+ *   - rejects non-object inputs (a JSON Schema is always an object;
+ *     `true`/`false` are technically valid 2020-12 but are nonsensical
+ *     here and indicate a configuration error).
+ *
+ * Compilation is the test: if Ajv can compile it, it's a valid schema.
+ * The error returned is the first compile-time error; this is fine for
+ * registration because operators iterate.
+ *
+ * @param schema - A JSON value that the caller believes is a JSON Schema.
+ * @returns `{ ok: true }` on success, `{ ok: false, error }` on failure.
+ *          Never throws — Ajv's compile errors are caught and converted.
+ */
+export function validateJsonSchema(schema: unknown): ValidateSchemaResult {
+  throw new Error("not implemented");
+}
+
+/**
+ * Validate `instance` against `schema` using a runtime-tolerant Ajv
+ * instance. Used by `submit_result` (output schema) and `task_tool`
+ * dispatch (input schema).
+ *
+ * Behaviour:
+ *   - Returns ALL errors, not just the first.
+ *   - Errors include JSON-Pointer paths (RFC 6901). Root errors yield
+ *     an empty path — the formatted string is `validation::<message>`.
+ *   - Extra unknown fields on objects are accepted unless the schema
+ *     itself sets `additionalProperties: false`. Ajv default behavior;
+ *     do not override.
+ *   - Compiled validators are cached by schema reference.
+ *
+ * Caller responsibilities:
+ *   - The schema MUST already have passed {@link validateJsonSchema}
+ *     at registration. This function does not re-validate the schema
+ *     shape — it only validates the instance.
+ *   - The generic `T` is a convenience for the caller; this function
+ *     does not narrow the type at runtime beyond Ajv's checks.
+ *
+ * @param schema - The JSON Schema to validate against.
+ * @param instance - The value to validate.
+ * @returns `{ ok: true, value }` on success;
+ *          `{ ok: false, errors }` with one or more `validation:<path>:<msg>`
+ *          strings on failure.
+ *          On schema compile failure (which should not happen in production
+ *          because schemas pass {@link validateJsonSchema} first), returns
+ *          `{ ok: false, errors: [<the compile error>] }`.
+ */
+export function validateAgainst<T = unknown>(
+  schema: unknown,
+  instance: unknown,
+): ValidateAgainstResult<T> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Internal: format a single Ajv error as the M0 envelope string token.
+ * Exported for testing only. The format is intentionally stable —
+ * downstream consumers parse it.
+ *
+ * @param err - An Ajv error object.
+ * @returns `validation:<instancePath>:<message>` — `instancePath` may be
+ *          the empty string for root-level errors.
+ */
+export function formatAjvError(err: ErrorObject): string {
+  throw new Error("not implemented");
+}

--- a/src/dispatch/validation.ts
+++ b/src/dispatch/validation.ts
@@ -49,6 +49,54 @@ import Ajv2020, { type ValidateFunction, type ErrorObject } from "ajv/dist/2020.
 import addFormats from "ajv-formats";
 
 /**
+ * Ajv instance used for registration-time schema-shape validation.
+ *
+ * `strict: true` rejects unknown keywords, unresolved `$ref`s,
+ * mismatched types, etc. — exactly what we want when an operator
+ * uploads a pipeline definition: typos like `requried` should be
+ * caught at upload, not at the first runtime validation.
+ *
+ * `allErrors: true` is harmless here (compile-time errors are first-
+ * fail anyway) but keeps both instances configured consistently.
+ *
+ * `ajv-formats` is loaded so format keywords like `format: "uri"`,
+ * `format: "date-time"`, etc. are recognized — the §3.1 jobseek
+ * pipeline uses `format: "uri"` on `canonical_website` and `board_url`.
+ */
+const registrationAjv = new Ajv2020({
+  strict: true,
+  allErrors: true,
+});
+addFormats(registrationAjv);
+
+/**
+ * Ajv instance used for runtime instance validation.
+ *
+ * `strict: 'log'` downgrades unknown-keyword errors to `console.warn`
+ * rather than failing compilation. This matters because a schema may
+ * be authored with forward-compatibility annotations (e.g. an
+ * `x-internal` extension); we don't want such a schema to break a
+ * submission. Schemas reach runtime only after passing
+ * {@link validateJsonSchema}, so genuinely-broken schemas are already
+ * filtered out by then.
+ *
+ * `allErrors: true` is the key behavior — we return EVERY validation
+ * failure for an instance, not just the first.
+ */
+const runtimeAjv = new Ajv2020({
+  strict: "log",
+  allErrors: true,
+});
+addFormats(runtimeAjv);
+
+/**
+ * Cache of compiled validators, keyed by schema reference.
+ * `WeakMap` so a schema that is no longer referenced is reclaimed
+ * along with its compiled function.
+ */
+const compiledCache = new WeakMap<object, ValidateFunction>();
+
+/**
  * Result of registration-time JSON Schema shape validation.
  *
  * A successful result carries no payload — the caller already holds
@@ -93,7 +141,35 @@ export type ValidateAgainstResult<T> =
  *          Never throws — Ajv's compile errors are caught and converted.
  */
 export function validateJsonSchema(schema: unknown): ValidateSchemaResult {
-  throw new Error("not implemented");
+  // Reject obviously non-schema inputs up front. A JSON Schema is
+  // always a JSON object in our world; `true`/`false` are technically
+  // valid 2020-12 schemas but they're nonsensical as a pipeline
+  // input/output schema and almost always indicate a configuration
+  // error in the YAML. Treat them as invalid.
+  if (
+    schema === null ||
+    typeof schema !== "object" ||
+    Array.isArray(schema)
+  ) {
+    return {
+      ok: false,
+      error: `:schema must be a JSON object, got ${
+        schema === null ? "null" : Array.isArray(schema) ? "array" : typeof schema
+      }`,
+    };
+  }
+
+  try {
+    // Compile through the strict instance. Any unknown keyword,
+    // unresolved $ref, or type-level malformation throws here.
+    registrationAjv.compile(schema);
+    return { ok: true };
+  } catch (err) {
+    // Ajv errors are strings/Errors. Surface a single-line message
+    // suitable for the offending-path response.
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
 }
 
 /**
@@ -130,7 +206,47 @@ export function validateAgainst<T = unknown>(
   schema: unknown,
   instance: unknown,
 ): ValidateAgainstResult<T> {
-  throw new Error("not implemented");
+  if (schema === null || typeof schema !== "object" || Array.isArray(schema)) {
+    return {
+      ok: false,
+      errors: [
+        `validation::schema must be a JSON object, got ${
+          schema === null ? "null" : Array.isArray(schema) ? "array" : typeof schema
+        }`,
+      ],
+    };
+  }
+
+  // Cache lookup — schemas are passed by reference from the pipelines
+  // table; the same object identity recurs across many calls.
+  let validate = compiledCache.get(schema);
+  if (validate === undefined) {
+    try {
+      validate = runtimeAjv.compile(schema);
+    } catch (err) {
+      // Should not happen in production: schemas pass `validateJsonSchema`
+      // at registration. If it does, surface the compile error so the
+      // dispatch handler can return a 500-style envelope.
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, errors: [`validation::${message}`] };
+    }
+    compiledCache.set(schema, validate);
+  }
+
+  const valid = validate(instance);
+  if (valid) {
+    return { ok: true, value: instance as T };
+  }
+
+  // `validate.errors` is non-null when `valid` is false. Defensive `?? []`
+  // for type narrowing only.
+  const errors = (validate.errors ?? []).map(formatAjvError);
+  // If Ajv somehow returned no error objects despite reporting invalid,
+  // ensure we still emit a non-empty errors array (M0 contract).
+  if (errors.length === 0) {
+    return { ok: false, errors: ["validation::unspecified validation error"] };
+  }
+  return { ok: false, errors };
 }
 
 /**
@@ -143,5 +259,8 @@ export function validateAgainst<T = unknown>(
  *          the empty string for root-level errors.
  */
 export function formatAjvError(err: ErrorObject): string {
-  throw new Error("not implemented");
+  // Ajv 2020 always populates `instancePath` (empty string at root).
+  // `message` is normally present but typed `string | undefined`;
+  // fall back to an empty string defensively.
+  return `validation:${err.instancePath}:${err.message ?? ""}`;
 }


### PR DESCRIPTION
## Summary
Adds `src/dispatch/validation.ts` exposing two pure utilities that the upcoming M4/M5/M7 routes will call:
- `validateJsonSchema(schema)` — registration-time check (Ajv 2020-12, `strict: true`, `allErrors: true`) used by `POST /pipelines` to reject malformed pipeline definitions before they enter the run loop
- `validateAgainst<T>(schema, instance)` — runtime instance validation (Ajv 2020-12, `strict: 'log'`, `allErrors: true`) used by `submit_result` and `task_tool` dispatch to validate outputs/args against pipeline-def schemas

Compiled validators are cached by schema reference in a `WeakMap`. `ajv-formats` is registered on both Ajv instances so the §3.1 jobseek YAML's `format: "uri"` fields work without extra wiring at the call site. Errors are formatted as `validation:<json-pointer>:<message>` per the M0 envelope (`Err.errors[]` accepts `string`).

## Related issue
Closes colophon-group/murmur#14

## Files changed (high-level)
- `src/dispatch/validation.ts` — the two utilities + `formatAjvError`, with the two Ajv instances configured per the issue's quality-gate requirements
- `src/dispatch/validation.test.ts` — full coverage of issue #14's Verification list (20 tests)
- `package.json`, `pnpm-lock.yaml` — add `ajv@^8.20.0` and `ajv-formats@^3.0.1`

## Verification (from the issue)
- [x] Valid JSON Schema compiles → no error
- [x] Schema with unknown keyword → `{ ok: false }` at registration with the offending path/message
- [x] Schema referencing undefined `$ref` → `{ ok: false }` at registration
- [x] `submit_result` with extra unknown field (no `additionalProperties: false`) → accepted
- [x] `submit_result` with type mismatch → `validation:/board_url:must be string`
- [x] `submit_result` with missing required field → `validation::must have required property 'verified'`
- [x] `task_tool` bad args → `validation:/board_url:must match pattern …`
- [x] Multiple errors all returned (not first-only)
- [x] §3.1 jobseek pipeline def (from `docs/contracts/fixtures/all-seven.json`) registers cleanly across `initial_input` + every subtask `output_schema` + every `input_schema`
- [x] Deliberately broken §3.1 (unknown keyword injected) is rejected
- [x] Error messages include JSON-Pointer paths (root → empty, nested → `/items/0/bar`)
- [x] M0 grep gate `pnpm grep-no-accepted-key` passes

## Manual checks run locally
- `pnpm typecheck` — green
- `pnpm lint` — green (zero warnings, no unused exports)
- `pnpm test` — 33 tests pass; coverage 97.14% lines / 83.87% branches on `src/dispatch/**` (gate: 85% / 75%)
- `pnpm grep:all` — all four gates green

## Notes for reviewer
- **Scope:** this PR delivers utilities only. The HTTP wiring (`POST /pipelines`, `submit_result`, `task_tool`) belongs to M4 (#9), M5 (#10), and M7 (#12), which are still blocked. The "Behavior" section of issue #14 is documented as the consumer contract, not as scope here.
- **`Ajv2020` import:** uses `ajv/dist/2020.js` (the 2020-12 meta-schema is bundled). Issue note 2 called out that Ajv7 / the default Ajv8 entry would silently mis-validate.
- **`strict` mode split:** `strict: true` at registration deliberately rejects typos like `requried`; `strict: 'log'` at runtime only logs unknown keywords (forward compat). Documented inline.
- **`additionalProperties` default:** Ajv default behavior — extra fields tolerated unless the schema sets `additionalProperties: false`. Confirmed by test, no override.
- **Cache:** `WeakMap<object, ValidateFunction>` keyed by schema reference. M4 stores schemas in the pipelines table so identity is stable per active pipeline.
- **Uncovered lines (247-248):** the "Ajv reported invalid but produced no error objects" defensive fallback. Branch is unreachable in normal operation; left in for safety so we never emit `errors: []` (M0 says `errors` MUST be non-empty).