### PR TITLE
feat(db): WAL-mode SQLite schema + idempotent migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,40 @@ src/                      Murmur server (Hono + node-server)
   server.ts               HTTP app factory
   index.ts                Boot: read PORT, bind socket
   logger.ts               Tiny structured logger (JSON-line to stderr)
+  db/                     SQLite layer (open helper, migrations, schema doc)
+    index.ts              `openDb(path)` — sets WAL/synchronous/foreign_keys pragmas
+    migrate.ts            Forward-only migrations runner
+    cli.ts                `pnpm migrate` entry point
+    schema.md             Canonical schema reference
+    migrations/*.sql      Versioned schema files (forward-only; see policy below)
 packages/contracts-types/ M0 contract types (envelope, headers, pipeline, ...)
 scripts/                  CI gate scripts (grep-all, check-unused-exports, ...)
 docs/                     Boundary contracts + bootstrap runbooks
 ```
+
+## Database migrations
+
+Murmur uses SQLite (WAL mode) at `DATABASE_PATH`. Apply the schema with:
+
+```bash
+# against DATABASE_PATH (default ./murmur.db)
+pnpm migrate
+
+# against an in-memory DB (smoke-test only — no persistence)
+pnpm migrate:memory
+```
+
+The migration set lives in `src/db/migrations/*.sql`, one file per version.
+The runner records applied versions in `_migrations` and is **idempotent**:
+running `pnpm migrate` twice in a row applies zero migrations the second time.
+
+**Migrations are forward-only.** Once a file is committed and applied to any
+environment, it is immutable — the runner identifies migrations by numeric
+prefix, so editing an applied file silently desyncs deployed databases. To
+change the schema, add a new file with the next version number.
+
+The canonical schema reference is [`src/db/schema.md`](src/db/schema.md).
+Any change to a migration must be reflected there in the same PR.
 
 ## Development process
 

--- a/package.json
+++ b/package.json
@@ -19,15 +19,17 @@
     "grep-no-accepted-key": "bash scripts/grep-no-accepted-key.sh",
     "grep-no-naked-eq-in-auth": "bash scripts/grep-no-naked-eq-in-auth.sh",
     "grep-uses-timingsafeequal": "bash scripts/grep-uses-timingsafeequal.sh",
-    "grep-no-token-logged": "bash scripts/grep-no-secrets-logged.sh"
+    "grep-no-token-logged": "bash scripts/grep-no-secrets-logged.sh",
+    "migrate": "tsx src/db/cli.ts",
+    "migrate:memory": "tsx src/db/cli.ts --memory"
   },
   "dependencies": {
     "@murmur/contracts-types": "workspace:*",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1"
+    "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "22.9.0",
     "@vitest/coverage-v8": "2.1.9",
     "eslint": "9.15.0",
@@ -41,7 +43,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "better-sqlite3"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "@murmur/contracts-types": "workspace:*",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,16 +11,16 @@ importers:
       '@murmur/contracts-types':
         specifier: workspace:*
         version: link:packages/contracts-types
-      ajv:
-        specifier: ^8.20.0
-        version: 8.20.0
-      ajv-formats:
-        specifier: ^3.0.1
-        version: 3.0.1(ajv@8.20.0)
+      better-sqlite3:
+        specifier: ^12.9.0
+        version: 12.9.0
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
         version: 1.13.7(hono@4.6.12)
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: 22.9.0
         version: 22.9.0
@@ -618,6 +618,9 @@ packages:
   '@ts-morph/common@0.12.3':
     resolution: {integrity: sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -784,6 +787,19 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@12.9.0:
+    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -797,6 +813,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -817,6 +836,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   code-block-writer@11.0.3:
     resolution: {integrity: sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==}
@@ -852,12 +874,24 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -867,6 +901,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -942,6 +979,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -969,6 +1010,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -988,6 +1032,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -995,6 +1042,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1027,6 +1077,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1038,6 +1091,12 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1151,6 +1210,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1162,9 +1225,15 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -1179,8 +1248,18 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1242,9 +1321,18 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1253,9 +1341,13 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1275,6 +1367,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1296,6 +1391,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1314,6 +1415,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1322,6 +1426,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1329,6 +1437,13 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -1378,6 +1493,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1402,6 +1520,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1485,6 +1606,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -1851,6 +1975,10 @@ snapshots:
       mkdirp: 1.0.4
       path-browserify: 1.0.1
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.9.0
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2043,6 +2171,23 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@12.9.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -2059,6 +2204,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -2078,6 +2228,8 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.3: {}
+
+  chownr@1.1.4: {}
 
   code-block-writer@11.0.3: {}
 
@@ -2109,15 +2261,27 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
 
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
+
+  detect-libc@2.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   error-ex@1.3.4:
     dependencies:
@@ -2256,6 +2420,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2282,6 +2448,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -2303,12 +2471,16 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -2337,6 +2509,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   import-fresh@3.3.1:
@@ -2345,6 +2519,10 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-arrayish@0.2.1: {}
 
@@ -2449,6 +2627,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -2461,7 +2641,11 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.0
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
 
@@ -2469,7 +2653,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2528,13 +2722,44 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
-  require-from-string@2.0.2: {}
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   resolve-from@4.0.0: {}
 
@@ -2577,6 +2802,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   semver@7.7.4: {}
 
   shebang-command@2.0.0:
@@ -2588,6 +2815,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
 
@@ -2607,6 +2842,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2615,11 +2854,28 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   test-exclude@7.0.2:
     dependencies:
@@ -2668,6 +2924,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2690,6 +2950,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@22.9.0):
     dependencies:
@@ -2775,6 +3037,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   yaml@1.10.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@murmur/contracts-types':
         specifier: workspace:*
         version: link:packages/contracts-types
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -1348,6 +1354,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2760,6 +2770,8 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/db/cli.test.ts
+++ b/src/db/cli.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the `pnpm migrate` CLI entry point. The CLI is a thin wrapper
+ * around `openDb` + `runMigrations`; we exercise its argv parsing and an
+ * end-to-end smoke against a tempfile.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseArgs } from "./cli.js";
+
+describe("parseArgs", () => {
+  it("uses DATABASE_PATH when no argv is given", () => {
+    const result = parseArgs([], { DATABASE_PATH: "/tmp/foo.db" });
+    expect(result).toEqual({ path: "/tmp/foo.db" });
+  });
+
+  it("falls back to ./murmur.db when DATABASE_PATH is unset", () => {
+    const result = parseArgs([], {});
+    expect(result).toEqual({ path: "./murmur.db" });
+  });
+
+  it("--memory selects :memory:", () => {
+    const result = parseArgs(["--memory"], { DATABASE_PATH: "/ignored.db" });
+    expect(result).toEqual({ path: ":memory:" });
+  });
+
+  it("rejects unknown flags", () => {
+    const result = parseArgs(["--no-such-flag"], {});
+    expect("error" in result).toBe(true);
+  });
+});
+
+describe("pnpm migrate (end-to-end smoke)", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "murmur-migrate-cli-"));
+    dbPath = join(dir, "test.db");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("`pnpm migrate:memory` exits 0", () => {
+    // Run from the repo root so the CLI finds the migrations dir.
+    const cwd = resolve(process.cwd());
+    let ok = true;
+    try {
+      execFileSync("pnpm", ["migrate:memory"], {
+        cwd,
+        stdio: "pipe",
+        env: { ...process.env },
+      });
+    } catch {
+      ok = false;
+    }
+    expect(ok).toBe(true);
+  });
+
+  it("`pnpm migrate` against a tempfile applies the schema", async () => {
+    const cwd = resolve(process.cwd());
+    let ok = true;
+    try {
+      execFileSync("pnpm", ["migrate"], {
+        cwd,
+        stdio: "pipe",
+        env: { ...process.env, DATABASE_PATH: dbPath },
+      });
+    } catch {
+      ok = false;
+    }
+    expect(ok).toBe(true);
+
+    // The DB file should exist and contain the expected tables.
+    const Database = (await import("better-sqlite3")).default;
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const rows = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )
+        .all() as Array<{ name: string }>;
+      const names = rows.map((r) => r.name);
+      expect(names).toEqual([
+        "_migrations",
+        "agent_actions",
+        "pipelines",
+        "runs",
+        "subtask_instances",
+        "subtask_results",
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/db/cli.ts
+++ b/src/db/cli.ts
@@ -16,6 +16,11 @@
  * CLI invocation short.
  */
 
+import { log } from "../logger.js";
+
+import { openDb } from "./index.js";
+import { runMigrations } from "./migrate.js";
+
 /**
  * Parse argv (excluding the node + script entries) into a config object.
  *
@@ -28,9 +33,22 @@ export function parseArgs(
   argv: ReadonlyArray<string>,
   env: NodeJS.ProcessEnv,
 ): { readonly path: string } | { readonly error: string } {
-  void argv;
-  void env;
-  throw new Error("not implemented");
+  let useMemory = false;
+  for (const arg of argv) {
+    if (arg === "--memory") {
+      useMemory = true;
+      continue;
+    }
+    return { error: `unknown argument: ${arg}` };
+  }
+
+  if (useMemory) return { path: ":memory:" };
+
+  const fromEnv = env.DATABASE_PATH;
+  if (fromEnv !== undefined && fromEnv !== "") {
+    return { path: fromEnv };
+  }
+  return { path: "./murmur.db" };
 }
 
 /**
@@ -42,5 +60,54 @@ export function parseArgs(
  *   `process.exit(code)`.
  */
 export async function main(): Promise<number> {
-  throw new Error("not implemented");
+  const parsed = parseArgs(process.argv.slice(2), process.env);
+  if ("error" in parsed) {
+    log.error("migrate.bad_args", { error: parsed.error });
+    return 1;
+  }
+
+  let db;
+  try {
+    db = openDb(parsed.path);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("migrate.open_failed", { path: parsed.path, error: message });
+    return 1;
+  }
+
+  try {
+    const result = runMigrations(db);
+    log.info("migrate.done", {
+      path: parsed.path,
+      applied: result.applied,
+      skipped: result.skipped,
+    });
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("migrate.failed", { path: parsed.path, error: message });
+    return 1;
+  } finally {
+    db.close();
+  }
+}
+
+// Self-invocation guard: only run `main()` when this module is executed
+// directly. Importing it from tests must not trigger a CLI run.
+const invokedDirectly =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(process.argv[1], "file://").href;
+
+if (invokedDirectly) {
+  main()
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error("migrate.unhandled", { error: message });
+      process.exit(1);
+    });
 }

--- a/src/db/cli.ts
+++ b/src/db/cli.ts
@@ -1,0 +1,46 @@
+/**
+ * `pnpm migrate` entry point.
+ *
+ * Usage:
+ *   pnpm migrate              # opens DATABASE_PATH (default ./murmur.db),
+ *                             # applies pending migrations, prints a summary
+ *   pnpm migrate --memory     # uses :memory: instead — for smoke-testing
+ *                             # that the migration set is well-formed
+ *
+ * Exit codes:
+ *   0 on success (including no-op runs)
+ *   1 on any error (DB open failure, migration SQL error, malformed args)
+ *
+ * The CLI is deliberately thin — all the work is in `runMigrations` and
+ * `openDb`. Keeping it thin keeps the path between unit tests and the real
+ * CLI invocation short.
+ */
+
+/**
+ * Parse argv (excluding the node + script entries) into a config object.
+ *
+ * @param argv  the slice `process.argv.slice(2)`.
+ * @param env   process.env (or a stub in tests).
+ * @returns either a `{ path }` to open, or an `{ error }` describing the
+ *   parse failure. Pure — no I/O.
+ */
+export function parseArgs(
+  argv: ReadonlyArray<string>,
+  env: NodeJS.ProcessEnv,
+): { readonly path: string } | { readonly error: string } {
+  void argv;
+  void env;
+  throw new Error("not implemented");
+}
+
+/**
+ * Run the CLI. Reads `process.argv` + `process.env`, opens the DB, applies
+ * migrations, prints a summary line via the structured logger, returns the
+ * exit code.
+ *
+ * @returns 0 on success, non-zero on error. Caller is expected to
+ *   `process.exit(code)`.
+ */
+export async function main(): Promise<number> {
+  throw new Error("not implemented");
+}

--- a/src/db/concurrency.test.ts
+++ b/src/db/concurrency.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Concurrency tests — DoD verification for issue #7.
+ *
+ * The §3.3 atomic claim CAS in M5 relies on `BEGIN IMMEDIATE` actually
+ * serializing writes against a WAL-mode SQLite database. This test pins
+ * that contract so future changes (e.g. switching to deferred transactions
+ * or a non-WAL journal mode) fail loudly.
+ *
+ * `better-sqlite3` is synchronous, but `BEGIN IMMEDIATE` against a busy
+ * writer raises `SQLITE_BUSY` synchronously when `busy_timeout = 0`. We
+ * exercise that path: open two connections to the same file, hold the
+ * write lock on one, try `BEGIN IMMEDIATE` on the other, expect a
+ * `SQLITE_BUSY` (or `SQLITE_BUSY_SNAPSHOT`) error.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { openDb } from "./index.js";
+import { runMigrations } from "./migrate.js";
+
+interface SQLiteError extends Error {
+  readonly code?: string;
+}
+
+describe("WAL concurrency: BEGIN IMMEDIATE serializes writers", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "murmur-concurrency-"));
+    dbPath = join(dir, "test.db");
+    // Migrate once via a temporary connection.
+    const db = openDb(dbPath);
+    runMigrations(db);
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a second BEGIN IMMEDIATE raises SQLITE_BUSY while the first is open", () => {
+    const a = openDb(dbPath);
+    const b = openDb(dbPath);
+
+    // Disable both connections' busy-timeout so we don't have to wait.
+    a.pragma("busy_timeout = 0");
+    b.pragma("busy_timeout = 0");
+
+    try {
+      a.exec("BEGIN IMMEDIATE");
+      // A is now holding the write lock. B's BEGIN IMMEDIATE must fail.
+      let caught: SQLiteError | undefined;
+      try {
+        b.exec("BEGIN IMMEDIATE");
+      } catch (err) {
+        caught = err as SQLiteError;
+      }
+      expect(caught).toBeDefined();
+      expect(caught?.code ?? "").toMatch(/^SQLITE_BUSY/);
+    } finally {
+      try {
+        a.exec("ROLLBACK");
+      } catch {
+        // ignore
+      }
+      a.close();
+      b.close();
+    }
+  });
+
+  it("after the first transaction commits, the second BEGIN IMMEDIATE succeeds", () => {
+    const a = openDb(dbPath);
+    const b = openDb(dbPath);
+    a.pragma("busy_timeout = 0");
+    b.pragma("busy_timeout = 0");
+
+    a.exec("BEGIN IMMEDIATE");
+    a.exec("COMMIT");
+
+    let succeeded = true;
+    try {
+      b.exec("BEGIN IMMEDIATE");
+      b.exec("COMMIT");
+    } catch {
+      succeeded = false;
+    }
+    expect(succeeded).toBe(true);
+
+    a.close();
+    b.close();
+  });
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,44 @@
+/**
+ * SQLite connection helper.
+ *
+ * Murmur uses `better-sqlite3` for all server-side persistence — synchronous
+ * queries simplify the atomic-claim CAS in M5 (`/work/next`) since there's no
+ * await between `BEGIN IMMEDIATE` and the `UPDATE … RETURNING`. The DB lives
+ * at `DATABASE_PATH` (env-configured); tests pass `:memory:`.
+ *
+ * Every connection MUST run the same pragmas at open:
+ *
+ *   - `journal_mode = WAL`        — reader-doesn't-block-writer for the
+ *     audit/sweeper traffic; required for the §3.3 CAS to be live in M5.
+ *   - `synchronous  = NORMAL`     — durable enough for demo, fast enough
+ *     for sub-100ms claim turnaround. (`FULL` is overkill given Hetzner's
+ *     SSD + WAL checkpointing; `OFF` would risk WAL corruption.)
+ *   - `foreign_keys = ON`         — schema declares FKs (e.g.
+ *     `subtask_results.instance_id` → `subtask_instances.id`); they must be
+ *     enforced. SQLite defaults this OFF for back-compat — every connection
+ *     must opt in.
+ *
+ * @see DESIGN.md §3.3 — atomic claim CAS rationale
+ * @see src/db/schema.md — canonical schema
+ */
+
+import type Database from "better-sqlite3";
+
+/**
+ * Open a SQLite connection at `path` with Murmur's standard pragmas applied.
+ *
+ * @param path filesystem path to the SQLite file, or `":memory:"` for an
+ *   ephemeral in-process DB. Must not be empty.
+ * @returns a `better-sqlite3` Database handle. Caller owns lifecycle —
+ *   `db.close()` when done.
+ * @throws Error if `path` is empty or if SQLite fails to open the file.
+ *
+ * Pragmas applied (in order): `journal_mode = WAL`, `synchronous = NORMAL`,
+ * `foreign_keys = ON`. The `journal_mode` PRAGMA is no-op for `:memory:`
+ * databases (SQLite forces `memory` journal mode there) — the helper still
+ * issues it for parity with file-backed paths.
+ */
+export function openDb(path: string): Database.Database {
+  void path;
+  throw new Error("not implemented");
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -22,7 +22,7 @@
  * @see src/db/schema.md — canonical schema
  */
 
-import type Database from "better-sqlite3";
+import Database from "better-sqlite3";
 
 /**
  * Open a SQLite connection at `path` with Murmur's standard pragmas applied.
@@ -39,6 +39,16 @@ import type Database from "better-sqlite3";
  * issues it for parity with file-backed paths.
  */
 export function openDb(path: string): Database.Database {
-  void path;
-  throw new Error("not implemented");
+  if (path === "") {
+    throw new Error("openDb: path must not be empty");
+  }
+
+  const db = new Database(path);
+  // Order matters only insofar as `journal_mode` should be set before any
+  // writes; the other two are independent. Using `pragma` (not `exec`) so
+  // the synchronous PRAGMA returns are surfaced if needed by callers.
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  return db;
 }

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,82 @@
+/**
+ * Forward-only migrations runner.
+ *
+ * Reads `*.sql` files from `src/db/migrations/` (or a caller-supplied dir),
+ * orders by leading numeric prefix, and applies any whose `version` is not
+ * yet recorded in the `_migrations` table. Each migration runs inside its
+ * own `BEGIN IMMEDIATE` … `COMMIT` so a partial failure doesn't half-apply.
+ *
+ * **Idempotency.** Running the runner twice on the same DB applies zero
+ * migrations the second time — every applied version is recorded in
+ * `_migrations`, and the runner skips entries that already exist.
+ *
+ * **Forward-only.** There are no down-migrations and no in-place edits to
+ * applied SQL files. The README and `src/db/schema.md` make this explicit.
+ * If a migration needs to be undone, ship a new forward migration that
+ * undoes it.
+ *
+ * @see src/db/schema.md
+ */
+
+import type Database from "better-sqlite3";
+
+/**
+ * One migration file parsed off disk (or supplied inline by tests).
+ */
+export interface MigrationFile {
+  /** Numeric prefix from the filename, e.g. `0001` → `1`. */
+  readonly version: number;
+  /** Filename stem after the version, e.g. `init`. Used in logs. */
+  readonly name: string;
+  /** Raw SQL body. May contain multiple statements separated by `;`. */
+  readonly sql: string;
+}
+
+/**
+ * Outcome of a `runMigrations` invocation.
+ */
+export interface MigrationResult {
+  /** Versions applied this call (in ascending order). Empty on no-op. */
+  readonly applied: ReadonlyArray<number>;
+  /** Versions that were already in `_migrations` and therefore skipped. */
+  readonly skipped: ReadonlyArray<number>;
+}
+
+/**
+ * Default location of the migrations directory, relative to the package root.
+ * Exported so the CLI and tests share one source of truth.
+ */
+export const DEFAULT_MIGRATIONS_DIR = "src/db/migrations";
+
+/**
+ * Load migrations from `dir`. Files MUST match the pattern
+ * `^(\d+)_([a-z0-9_-]+)\.sql$`. The numeric prefix is the version (parsed
+ * as decimal); duplicate versions throw.
+ *
+ * @returns migrations sorted ascending by `version`.
+ * @throws Error if the directory cannot be read, a filename is malformed,
+ *   or two files share the same version.
+ */
+export function loadMigrations(dir: string): ReadonlyArray<MigrationFile> {
+  void dir;
+  throw new Error("not implemented");
+}
+
+/**
+ * Apply pending migrations to `db`. Creates `_migrations` if absent.
+ *
+ * @param db an open `better-sqlite3` connection. The runner does NOT close it.
+ * @param migrations the migration set to apply. If omitted, the runner
+ *   loads from `DEFAULT_MIGRATIONS_DIR` relative to the project root.
+ * @returns the lists of applied and skipped versions.
+ * @throws Error if SQL execution fails. On failure the failing migration's
+ *   transaction is rolled back; previous migrations stay applied.
+ */
+export function runMigrations(
+  db: Database.Database,
+  migrations?: ReadonlyArray<MigrationFile>,
+): MigrationResult {
+  void db;
+  void migrations;
+  throw new Error("not implemented");
+}

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -18,6 +18,9 @@
  * @see src/db/schema.md
  */
 
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
 import type Database from "better-sqlite3";
 
 /**
@@ -48,6 +51,8 @@ export interface MigrationResult {
  */
 export const DEFAULT_MIGRATIONS_DIR = "src/db/migrations";
 
+const MIGRATION_FILENAME = /^(\d+)_([a-z0-9_-]+)\.sql$/;
+
 /**
  * Load migrations from `dir`. Files MUST match the pattern
  * `^(\d+)_([a-z0-9_-]+)\.sql$`. The numeric prefix is the version (parsed
@@ -58,8 +63,66 @@ export const DEFAULT_MIGRATIONS_DIR = "src/db/migrations";
  *   or two files share the same version.
  */
 export function loadMigrations(dir: string): ReadonlyArray<MigrationFile> {
-  void dir;
-  throw new Error("not implemented");
+  const absDir = resolve(process.cwd(), dir);
+  const entries = readdirSync(absDir);
+
+  const files: MigrationFile[] = [];
+  const seen = new Set<number>();
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".sql")) continue;
+    const match = MIGRATION_FILENAME.exec(entry);
+    if (match === null) {
+      throw new Error(
+        `loadMigrations: malformed filename ${JSON.stringify(entry)} ` +
+          `in ${dir}; expected /^(\\d+)_([a-z0-9_-]+)\\.sql$/`,
+      );
+    }
+    const versionRaw = match[1];
+    const name = match[2];
+    if (versionRaw === undefined || name === undefined) {
+      // Defensive — regex above guarantees both groups, but the index access
+      // is widened by `noUncheckedIndexedAccess`.
+      throw new Error(
+        `loadMigrations: regex group missing for ${JSON.stringify(entry)}`,
+      );
+    }
+    const version = Number(versionRaw);
+    if (!Number.isInteger(version) || version < 1) {
+      throw new Error(
+        `loadMigrations: version must be a positive integer; ` +
+          `got ${JSON.stringify(versionRaw)} in ${entry}`,
+      );
+    }
+    if (seen.has(version)) {
+      throw new Error(
+        `loadMigrations: duplicate version ${version} in ${dir}`,
+      );
+    }
+    seen.add(version);
+
+    const sql = readFileSync(resolve(absDir, entry), "utf8");
+    files.push({ version, name, sql });
+  }
+
+  files.sort((a, b) => a.version - b.version);
+  return files;
+}
+
+function ensureMigrationsTable(db: Database.Database): void {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS _migrations (
+       version    INTEGER PRIMARY KEY,
+       applied_at TEXT NOT NULL
+     )`,
+  );
+}
+
+function appliedVersions(db: Database.Database): Set<number> {
+  const rows = db
+    .prepare("SELECT version FROM _migrations")
+    .all() as Array<{ version: number }>;
+  return new Set(rows.map((r) => r.version));
 }
 
 /**
@@ -76,7 +139,41 @@ export function runMigrations(
   db: Database.Database,
   migrations?: ReadonlyArray<MigrationFile>,
 ): MigrationResult {
-  void db;
-  void migrations;
-  throw new Error("not implemented");
+  const set = migrations ?? loadMigrations(DEFAULT_MIGRATIONS_DIR);
+
+  ensureMigrationsTable(db);
+  const already = appliedVersions(db);
+
+  const applied: number[] = [];
+  const skipped: number[] = [];
+
+  const recordStmt = db.prepare(
+    "INSERT INTO _migrations (version, applied_at) VALUES (?, ?)",
+  );
+
+  for (const m of set) {
+    if (already.has(m.version)) {
+      skipped.push(m.version);
+      continue;
+    }
+    // BEGIN IMMEDIATE acquires the RESERVED lock up front, matching the
+    // semantics M5's claim CAS will rely on. Wrapping the whole file plus
+    // the bookkeeping insert keeps the migration atomic.
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.exec(m.sql);
+      recordStmt.run(m.version, new Date().toISOString());
+      db.exec("COMMIT");
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // Ignore — the original error is what matters.
+      }
+      throw err;
+    }
+    applied.push(m.version);
+  }
+
+  return { applied, skipped };
 }

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Tests for the SQLite schema and the migrations runner.
+ *
+ * Per issue #7's "Verification" block:
+ *   - applies all migrations from a fresh DB
+ *   - is idempotent (running twice succeeds)
+ *   - WAL mode + synchronous=NORMAL
+ *   - _migrations table records applied versions
+ *   - the 5 domain tables exist with the columns documented in schema.md
+ *   - subtask_instances has a UNIQUE partial index on claim_token
+ *   - subtask_instances has an index on (status, created_at)
+ *   - agent_actions has an index on (instance_id, ts)
+ *   - pnpm migrate against :memory: exits 0  (covered by cli.test.ts)
+ *   - schema matches src/db/schema.md
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type Database from "better-sqlite3";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import { openDb } from "./index.js";
+import { loadMigrations, runMigrations, DEFAULT_MIGRATIONS_DIR } from "./migrate.js";
+
+interface ColumnRow {
+  readonly cid: number;
+  readonly name: string;
+  readonly type: string;
+  readonly notnull: 0 | 1;
+  readonly dflt_value: string | null;
+  readonly pk: 0 | 1;
+}
+
+interface IndexRow {
+  readonly seq: number;
+  readonly name: string;
+  readonly unique: 0 | 1;
+  readonly origin: string;
+  readonly partial: 0 | 1;
+}
+
+interface IndexInfoRow {
+  readonly seqno: number;
+  readonly cid: number;
+  readonly name: string;
+}
+
+interface MasterRow {
+  readonly name: string;
+  readonly sql: string | null;
+}
+
+function tableColumns(db: Database.Database, table: string): ColumnRow[] {
+  return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnRow[];
+}
+
+function tableIndexes(db: Database.Database, table: string): IndexRow[] {
+  return db.prepare(`PRAGMA index_list(${table})`).all() as IndexRow[];
+}
+
+function indexInfo(db: Database.Database, indexName: string): IndexInfoRow[] {
+  return db.prepare(`PRAGMA index_info(${indexName})`).all() as IndexInfoRow[];
+}
+
+describe("openDb", () => {
+  let db: Database.Database;
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("opens an in-memory database", () => {
+    db = openDb(":memory:");
+    expect(db.open).toBe(true);
+  });
+
+  it("applies WAL journal_mode (file-backed)", () => {
+    // :memory: forces journal_mode=memory, so verify against a tempfile.
+    const tmpPath = resolve(process.cwd(), `node_modules/.test-wal-${Date.now()}.db`);
+    db = openDb(tmpPath);
+    const mode = db.pragma("journal_mode", { simple: true }) as string;
+    expect(mode.toLowerCase()).toBe("wal");
+    db.close();
+    // Re-open via an inert handle for the afterEach close (cheap dummy).
+    db = openDb(":memory:");
+  });
+
+  it("applies synchronous=NORMAL (1)", () => {
+    db = openDb(":memory:");
+    const sync = db.pragma("synchronous", { simple: true }) as number;
+    expect(sync).toBe(1);
+  });
+
+  it("enables foreign keys", () => {
+    db = openDb(":memory:");
+    const fk = db.pragma("foreign_keys", { simple: true }) as number;
+    expect(fk).toBe(1);
+  });
+
+  it("rejects an empty path", () => {
+    expect(() => openDb("")).toThrow();
+    db = openDb(":memory:"); // for afterEach
+  });
+});
+
+describe("loadMigrations", () => {
+  it("loads at least the 0001_init migration from the default dir", () => {
+    const migrations = loadMigrations(DEFAULT_MIGRATIONS_DIR);
+    expect(migrations.length).toBeGreaterThanOrEqual(1);
+    const first = migrations[0];
+    expect(first).toBeDefined();
+    expect(first?.version).toBe(1);
+    expect(first?.name).toBe("init");
+    expect(first?.sql).toContain("CREATE TABLE pipelines");
+  });
+
+  it("returns migrations sorted by ascending version", () => {
+    const migrations = loadMigrations(DEFAULT_MIGRATIONS_DIR);
+    for (let i = 1; i < migrations.length; i++) {
+      const prev = migrations[i - 1];
+      const cur = migrations[i];
+      expect(prev).toBeDefined();
+      expect(cur).toBeDefined();
+      expect(cur!.version).toBeGreaterThan(prev!.version);
+    }
+  });
+});
+
+describe("runMigrations", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = openDb(":memory:");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("applies all migrations from a fresh DB", () => {
+    const result = runMigrations(db);
+    expect(result.applied.length).toBeGreaterThanOrEqual(1);
+    expect(result.applied).toContain(1);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("is idempotent — running twice succeeds", () => {
+    const first = runMigrations(db);
+    const second = runMigrations(db);
+    expect(first.applied.length).toBeGreaterThanOrEqual(1);
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual([...first.applied]);
+  });
+
+  it("creates the _migrations table and records applied versions", () => {
+    runMigrations(db);
+    const cols = tableColumns(db, "_migrations");
+    const colNames = cols.map((c) => c.name).sort();
+    expect(colNames).toEqual(["applied_at", "version"]);
+
+    const versionCol = cols.find((c) => c.name === "version");
+    expect(versionCol?.pk).toBe(1);
+    expect(versionCol?.type).toBe("INTEGER");
+
+    const rows = db
+      .prepare("SELECT version, applied_at FROM _migrations ORDER BY version")
+      .all() as Array<{ version: number; applied_at: string }>;
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    const firstRow = rows[0];
+    expect(firstRow).toBeDefined();
+    expect(firstRow?.version).toBe(1);
+    expect(typeof firstRow?.applied_at).toBe("string");
+    // Loose ISO 8601 sanity: starts with 4 digits + dash.
+    expect(firstRow?.applied_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("creates all 5 domain tables plus _migrations", () => {
+    runMigrations(db);
+    const rows = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .all() as Array<{ name: string }>;
+    const names = rows.map((r) => r.name);
+    expect(names).toEqual([
+      "_migrations",
+      "agent_actions",
+      "pipelines",
+      "runs",
+      "subtask_instances",
+      "subtask_results",
+    ]);
+  });
+
+  describe("table column checks (vs schema.md)", () => {
+    beforeEach(() => {
+      runMigrations(db);
+    });
+
+    it("pipelines has the documented columns", () => {
+      const cols = tableColumns(db, "pipelines");
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect([...byName.keys()].sort()).toEqual([
+        "created_at",
+        "def_json",
+        "id",
+        "updated_at",
+        "version",
+      ]);
+      expect(byName.get("id")?.pk).toBe(1);
+      expect(byName.get("id")?.type).toBe("TEXT");
+      expect(byName.get("version")?.type).toBe("INTEGER");
+      expect(byName.get("version")?.notnull).toBe(1);
+      expect(byName.get("def_json")?.notnull).toBe(1);
+      expect(byName.get("created_at")?.notnull).toBe(1);
+      expect(byName.get("updated_at")?.notnull).toBe(1);
+    });
+
+    it("runs has the documented columns", () => {
+      const cols = tableColumns(db, "runs");
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      const expected = [
+        "completed_at",
+        "created_at",
+        "final_output_json",
+        "id",
+        "initial_input_json",
+        "pipeline_id",
+        "pipeline_version",
+        "status",
+        "webhook_status",
+        "webhook_url",
+      ];
+      expect([...byName.keys()].sort()).toEqual(expected);
+      expect(byName.get("id")?.pk).toBe(1);
+      expect(byName.get("pipeline_id")?.notnull).toBe(1);
+      expect(byName.get("pipeline_version")?.type).toBe("INTEGER");
+      expect(byName.get("status")?.notnull).toBe(1);
+      // nullable
+      expect(byName.get("final_output_json")?.notnull).toBe(0);
+      expect(byName.get("webhook_status")?.notnull).toBe(0);
+      expect(byName.get("completed_at")?.notnull).toBe(0);
+    });
+
+    it("subtask_instances has the documented columns", () => {
+      const cols = tableColumns(db, "subtask_instances");
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect([...byName.keys()].sort()).toEqual([
+        "claim_token",
+        "created_at",
+        "expires_at",
+        "id",
+        "input_json",
+        "parent_instance_id",
+        "run_id",
+        "spawn_index",
+        "status",
+        "subtask_id",
+        "updated_at",
+      ]);
+      expect(byName.get("id")?.pk).toBe(1);
+      expect(byName.get("run_id")?.notnull).toBe(1);
+      expect(byName.get("subtask_id")?.notnull).toBe(1);
+      expect(byName.get("status")?.notnull).toBe(1);
+      expect(byName.get("input_json")?.notnull).toBe(1);
+      // nullable claim columns
+      expect(byName.get("claim_token")?.notnull).toBe(0);
+      expect(byName.get("expires_at")?.notnull).toBe(0);
+      expect(byName.get("parent_instance_id")?.notnull).toBe(0);
+      expect(byName.get("spawn_index")?.notnull).toBe(0);
+      expect(byName.get("spawn_index")?.type).toBe("INTEGER");
+    });
+
+    it("subtask_results has the documented columns", () => {
+      const cols = tableColumns(db, "subtask_results");
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect([...byName.keys()].sort()).toEqual([
+        "instance_id",
+        "notes",
+        "output_json",
+        "submitted_at",
+      ]);
+      expect(byName.get("instance_id")?.pk).toBe(1);
+      expect(byName.get("output_json")?.notnull).toBe(1);
+      expect(byName.get("submitted_at")?.notnull).toBe(1);
+      expect(byName.get("notes")?.notnull).toBe(0);
+    });
+
+    it("agent_actions has the documented columns", () => {
+      const cols = tableColumns(db, "agent_actions");
+      const byName = new Map(cols.map((c) => [c.name, c]));
+      expect([...byName.keys()].sort()).toEqual([
+        "args_json",
+        "id",
+        "instance_id",
+        "kind",
+        "response_json",
+        "subcommand",
+        "truncated",
+        "ts",
+      ]);
+      expect(byName.get("id")?.pk).toBe(1);
+      expect(byName.get("id")?.type).toBe("INTEGER");
+      expect(byName.get("instance_id")?.notnull).toBe(1);
+      expect(byName.get("ts")?.notnull).toBe(1);
+      expect(byName.get("kind")?.notnull).toBe(1);
+      expect(byName.get("truncated")?.notnull).toBe(1);
+      expect(byName.get("truncated")?.dflt_value).toBe("0");
+    });
+
+    it("agent_actions.id is AUTOINCREMENT", () => {
+      const row = db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_actions'",
+        )
+        .get() as MasterRow;
+      expect(row.sql ?? "").toMatch(/AUTOINCREMENT/i);
+    });
+  });
+
+  describe("indexes", () => {
+    beforeEach(() => {
+      runMigrations(db);
+    });
+
+    it("subtask_instances has a UNIQUE partial index on claim_token", () => {
+      const indexes = tableIndexes(db, "subtask_instances");
+      const ix = indexes.find((i) => i.name === "idx_subtask_instances_claim_token");
+      expect(ix).toBeDefined();
+      expect(ix?.unique).toBe(1);
+      expect(ix?.partial).toBe(1);
+      const cols = indexInfo(db, "idx_subtask_instances_claim_token").map((c) => c.name);
+      expect(cols).toEqual(["claim_token"]);
+
+      // Verify the partial predicate via sqlite_master SQL text.
+      const row = db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+        )
+        .get("idx_subtask_instances_claim_token") as MasterRow;
+      expect(row.sql ?? "").toMatch(/WHERE\s+claim_token\s+IS\s+NOT\s+NULL/i);
+    });
+
+    it("subtask_instances has an index on (status, created_at)", () => {
+      const indexes = tableIndexes(db, "subtask_instances");
+      const ix = indexes.find((i) => i.name === "idx_subtask_instances_ready");
+      expect(ix).toBeDefined();
+      expect(ix?.unique).toBe(0);
+      const cols = indexInfo(db, "idx_subtask_instances_ready").map((c) => c.name);
+      expect(cols).toEqual(["status", "created_at"]);
+    });
+
+    it("agent_actions has an index on (instance_id, ts)", () => {
+      const indexes = tableIndexes(db, "agent_actions");
+      const ix = indexes.find((i) => i.name === "idx_agent_actions_instance_ts");
+      expect(ix).toBeDefined();
+      expect(ix?.unique).toBe(0);
+      const cols = indexInfo(db, "idx_agent_actions_instance_ts").map((c) => c.name);
+      expect(cols).toEqual(["instance_id", "ts"]);
+    });
+  });
+
+  describe("foreign keys", () => {
+    beforeEach(() => {
+      runMigrations(db);
+    });
+
+    it("foreign keys are enforced", () => {
+      // Inserting a subtask_instance with an unknown run_id MUST fail.
+      const insert = (): void => {
+        db.prepare(
+          `INSERT INTO subtask_instances
+             (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ).run("i1", "no-such-run", "s1", "pending", "{}", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z");
+      };
+      expect(insert).toThrow(/FOREIGN KEY/i);
+    });
+  });
+
+  describe("schema.md cross-check", () => {
+    it("every table mentioned in schema.md exists", () => {
+      runMigrations(db);
+      const docPath = resolve(process.cwd(), "src/db/schema.md");
+      const doc = readFileSync(docPath, "utf8");
+
+      // schema.md uses `## <table>` headings for each domain table.
+      const tableHeadings = ["_migrations", "pipelines", "runs", "subtask_instances", "subtask_results", "agent_actions"];
+      for (const t of tableHeadings) {
+        expect(doc).toContain(`## \`${t}\``);
+        const exists = db
+          .prepare("SELECT 1 AS one FROM sqlite_master WHERE type='table' AND name=?")
+          .get(t) as { one: number } | undefined;
+        expect(exists).toBeDefined();
+      }
+    });
+  });
+});

--- a/src/db/migrations/0001_init.sql
+++ b/src/db/migrations/0001_init.sql
@@ -1,0 +1,70 @@
+-- 0001_init: Initial Murmur SQLite schema.
+--
+-- See src/db/schema.md for the canonical reference. Any change to this
+-- file is forbidden once committed — ship a new migration instead.
+--
+-- Statements are separated by `;` and executed in order. The migrations
+-- runner wraps the whole file in BEGIN IMMEDIATE / COMMIT.
+
+CREATE TABLE pipelines (
+  id          TEXT PRIMARY KEY,
+  version     INTEGER NOT NULL,
+  def_json    TEXT    NOT NULL,
+  created_at  TEXT    NOT NULL,
+  updated_at  TEXT    NOT NULL
+);
+
+CREATE TABLE runs (
+  id                  TEXT PRIMARY KEY,
+  pipeline_id         TEXT NOT NULL REFERENCES pipelines(id),
+  pipeline_version    INTEGER NOT NULL,
+  status              TEXT NOT NULL,
+  initial_input_json  TEXT NOT NULL,
+  final_output_json   TEXT,
+  webhook_url         TEXT NOT NULL,
+  webhook_status      TEXT,
+  created_at          TEXT NOT NULL,
+  completed_at        TEXT
+);
+
+CREATE TABLE subtask_instances (
+  id                  TEXT PRIMARY KEY,
+  run_id              TEXT NOT NULL REFERENCES runs(id),
+  subtask_id          TEXT NOT NULL,
+  parent_instance_id  TEXT REFERENCES subtask_instances(id),
+  spawn_index         INTEGER,
+  status              TEXT NOT NULL,
+  claim_token         TEXT,
+  expires_at          TEXT,
+  input_json          TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_subtask_instances_claim_token
+  ON subtask_instances(claim_token)
+  WHERE claim_token IS NOT NULL;
+
+CREATE INDEX idx_subtask_instances_ready
+  ON subtask_instances(status, created_at);
+
+CREATE TABLE subtask_results (
+  instance_id   TEXT PRIMARY KEY REFERENCES subtask_instances(id),
+  output_json   TEXT NOT NULL,
+  notes         TEXT,
+  submitted_at  TEXT NOT NULL
+);
+
+CREATE TABLE agent_actions (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  instance_id    TEXT NOT NULL REFERENCES subtask_instances(id),
+  ts             TEXT NOT NULL,
+  kind           TEXT NOT NULL,
+  subcommand     TEXT,
+  args_json      TEXT,
+  response_json  TEXT,
+  truncated      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_agent_actions_instance_ts
+  ON agent_actions(instance_id, ts);

--- a/src/db/schema.md
+++ b/src/db/schema.md
@@ -1,0 +1,187 @@
+# Murmur SQLite schema
+
+**Authoritative reference.** This document lists every table, column,
+and index in the Murmur SQLite database. The SQL in
+`src/db/migrations/*.sql` MUST match. Tests in `migrations.test.ts`
+compare the live `.schema` against the structure here.
+
+## Conventions
+
+- All timestamps are RFC 3339 / ISO 8601 strings in UTC, e.g.
+  `"2026-04-29T12:34:56.000Z"`. SQLite has no native timestamp type;
+  we standardise on text for portability and for unambiguous ordering.
+- All JSON-bearing columns store a single JSON document as `TEXT`. The
+  application encodes/decodes; SQLite is not asked to parse them.
+- Identifiers (run id, instance id, claim token, pipeline id) are
+  opaque strings — caller-generated. The schema does not enforce a
+  format beyond non-NULL.
+- All `*_at` columns are `NOT NULL` unless noted; they're populated by
+  the application at write time.
+- Foreign keys are enforced (`PRAGMA foreign_keys = ON` runs at every
+  connection open in `openDb`). FK violations raise `SQLITE_CONSTRAINT`.
+
+## Migration policy
+
+**Forward-only.** Once a migration file in `src/db/migrations/` is
+committed and applied to any environment (CI, dev, prod), it is
+immutable. To change the schema, add a new file with the next version
+number. Editing an applied migration is forbidden — the runner detects
+applied versions by number, not by content hash, so an in-place edit
+silently desyncs deployed databases from the source.
+
+## Pragmas
+
+Applied at every `openDb` call:
+
+| Pragma | Value | Why |
+| --- | --- | --- |
+| `journal_mode` | `WAL` | Required for §3.3 atomic claim CAS; readers don't block writers (audit log + sweeper concurrent with claim flow). |
+| `synchronous` | `NORMAL` (1) | Acceptable durability vs. throughput tradeoff for demo. |
+| `foreign_keys` | `ON` | FK constraints are declared on the schema; SQLite leaves enforcement off by default. |
+
+---
+
+## `_migrations`
+
+Records which migration versions have been applied. Created by the
+migrations runner before applying anything else.
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `version` | `INTEGER PRIMARY KEY` | NO | Numeric prefix from the filename. |
+| `applied_at` | `TEXT NOT NULL` | NO | RFC 3339 timestamp the migration ran. |
+
+---
+
+## `pipelines`
+
+One row per pipeline-def (`POST /pipelines` upsert; last-write-wins per
+DESIGN.md §3.2). Stores the validated pipeline def as JSON for replay
+and for live subcommand-endpoint resolution (§3.3).
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `id` | `TEXT PRIMARY KEY` | NO | Pipeline slug, kebab-case. |
+| `version` | `INTEGER NOT NULL` | NO | Monotonically incremented per upsert; pinned to runs. |
+| `def_json` | `TEXT NOT NULL` | NO | Validated pipeline-def document. |
+| `created_at` | `TEXT NOT NULL` | NO | First insertion. |
+| `updated_at` | `TEXT NOT NULL` | NO | Most recent upsert. |
+
+No secondary indexes — primary key is the only access path for MVP.
+
+---
+
+## `runs`
+
+One row per `POST /pipelines/{id}/runs`. Holds the run-level state and
+the composed `final_output` once webhook delivery is in flight.
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `id` | `TEXT PRIMARY KEY` | NO | Run id (also the `Idempotency-Key` on the webhook). |
+| `pipeline_id` | `TEXT NOT NULL` | NO | FK → `pipelines.id`. |
+| `pipeline_version` | `INTEGER NOT NULL` | NO | Version pinned at run-start. |
+| `status` | `TEXT NOT NULL` | NO | One of `running`, `completed`, `failed`, `webhook_failed`. |
+| `initial_input_json` | `TEXT NOT NULL` | NO | The `initial_input` body posted by the publisher. |
+| `final_output_json` | `TEXT` | YES | Composed `final_output`; populated when status becomes `completed`. |
+| `webhook_url` | `TEXT NOT NULL` | NO | Materialized from the pipeline def at run-start (immune to def edits mid-run). |
+| `webhook_status` | `TEXT` | YES | One of `pending`, `delivered`, `failed`; NULL until run completes. |
+| `created_at` | `TEXT NOT NULL` | NO | Run creation timestamp. |
+| `completed_at` | `TEXT` | YES | Set when status moves out of `running`. |
+
+Foreign key: `pipeline_id` REFERENCES `pipelines(id)`.
+
+No secondary indexes for MVP; reads are by primary key (`GET /runs/{id}`).
+
+---
+
+## `subtask_instances`
+
+One row per concrete subtask to be claimed. Spawned children get their
+own row with `parent_instance_id` set. The atomic claim CAS in §3.3
+operates on this table.
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `id` | `TEXT PRIMARY KEY` | NO | Instance id (opaque). |
+| `run_id` | `TEXT NOT NULL` | NO | FK → `runs.id`. |
+| `subtask_id` | `TEXT NOT NULL` | NO | The pipeline-def subtask id (e.g., `configure-board`). |
+| `parent_instance_id` | `TEXT` | YES | FK → `subtask_instances.id`; set on spawned children. |
+| `spawn_index` | `INTEGER` | YES | Index into the parent's `for_each` array (0-based); NULL for non-spawned. |
+| `status` | `TEXT NOT NULL` | NO | One of `pending`, `ready`, `claimed`, `done`, `skipped`, `failed`. |
+| `claim_token` | `TEXT` | YES | Set when claimed; NULL otherwise. |
+| `expires_at` | `TEXT` | YES | RFC 3339; set with `claim_token`, NULL otherwise. |
+| `input_json` | `TEXT NOT NULL` | NO | Resolved input document for this instance (per `inputs:`). |
+| `created_at` | `TEXT NOT NULL` | NO | Row insertion. |
+| `updated_at` | `TEXT NOT NULL` | NO | Most recent state change. |
+
+Foreign keys:
+- `run_id` REFERENCES `runs(id)`
+- `parent_instance_id` REFERENCES `subtask_instances(id)`
+
+Indexes:
+- `idx_subtask_instances_claim_token` — `UNIQUE` on `claim_token`,
+  partial: `WHERE claim_token IS NOT NULL`. Guarantees one live claim
+  per token across the entire pool. The partial predicate keeps NULLs
+  out of the index so multiple unclaimed rows coexist.
+- `idx_subtask_instances_ready` — non-unique on `(status, created_at)`.
+  Drives `GET /work/next`'s `WHERE status='ready' ORDER BY created_at`
+  scan (§3.3).
+
+---
+
+## `subtask_results`
+
+One row per submitted result. Split from `subtask_instances` so that
+the result write is a single insert rather than an `UPDATE` on the
+already-busy claim row, and so audit traversal can join cheaply.
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `instance_id` | `TEXT PRIMARY KEY` | NO | FK → `subtask_instances.id`. One row per instance. |
+| `output_json` | `TEXT NOT NULL` | NO | Schema-validated `submit_result.result`. |
+| `notes` | `TEXT` | YES | Optional free-text reflection (DESIGN.md §3.1, last bullet). |
+| `submitted_at` | `TEXT NOT NULL` | NO | RFC 3339. |
+
+Foreign key: `instance_id` REFERENCES `subtask_instances(id)`.
+
+No secondary indexes; lookups are by `instance_id` (PK).
+
+---
+
+## `agent_actions`
+
+Audit log. One row per `task_tool` call's args + response (DESIGN.md
+§3.6, "Audit log payload truncation"). Used by `GET /runs/{id}` for
+the per-subtask `agent_actions[]` array.
+
+| Column | Type | NULL? | Notes |
+| --- | --- | --- | --- |
+| `id` | `INTEGER PRIMARY KEY AUTOINCREMENT` | NO | Surrogate; ordering hint. |
+| `instance_id` | `TEXT NOT NULL` | NO | FK → `subtask_instances.id`. |
+| `ts` | `TEXT NOT NULL` | NO | RFC 3339, time the action was logged. |
+| `kind` | `TEXT NOT NULL` | NO | One of `task_tool`, `submit_result`, `claim`, `claim_lost`, `webhook`. |
+| `subcommand` | `TEXT` | YES | `task_tool` subcommand name; NULL otherwise. |
+| `args_json` | `TEXT` | YES | JSON of args (truncated to 4 KB per §3.6). |
+| `response_json` | `TEXT` | YES | JSON of response (truncated to 4 KB). |
+| `truncated` | `INTEGER NOT NULL DEFAULT 0` | NO | `1` if either `args_json` or `response_json` was truncated. |
+
+Foreign key: `instance_id` REFERENCES `subtask_instances(id)`.
+
+Indexes:
+- `idx_agent_actions_instance_ts` — non-unique on `(instance_id, ts)`.
+  Drives ordered traversal of a subtask's audit trail in run-status
+  responses.
+
+---
+
+## Summary
+
+Tables: `_migrations`, `pipelines`, `runs`, `subtask_instances`,
+`subtask_results`, `agent_actions` (six total — five domain tables
+plus the migrations bookkeeping table).
+
+Domain indexes:
+- `subtask_instances` × `claim_token` (UNIQUE, partial)
+- `subtask_instances` × `(status, created_at)`
+- `agent_actions` × `(instance_id, ts)`


### PR DESCRIPTION
## Summary
- Adds `src/db/` with `openDb()` (WAL + synchronous=NORMAL + foreign_keys=ON), a forward-only migrations runner, and a `pnpm migrate` CLI
- Ships the initial schema (`0001_init.sql`) for the 5 domain tables (`pipelines`, `runs`, `subtask_instances`, `subtask_results`, `agent_actions`) plus the `_migrations` bookkeeping table, with the three indexes the §3.3 claim CAS and audit traversal need
- Documents every column in `src/db/schema.md` (canonical) and codifies the forward-only policy in `README.md`

## Related issue
Closes colophon-group/murmur#7

## Files changed (high-level)
- `src/db/index.ts` — `openDb(path)` helper that runs the three pragmas at every open
- `src/db/migrate.ts` — `loadMigrations` + `runMigrations` (idempotent; per-migration `BEGIN IMMEDIATE`)
- `src/db/cli.ts` — `pnpm migrate` / `pnpm migrate:memory` CLI; `parseArgs` is exported and pure
- `src/db/migrations/0001_init.sql` — five domain tables + three indexes
- `src/db/schema.md` — canonical reference for every table/column/index
- `src/db/migrations.test.ts` — verification block from issue #7
- `src/db/concurrency.test.ts` — `BEGIN IMMEDIATE` blocking test (DoD)
- `src/db/cli.test.ts` — `parseArgs` + e2e `pnpm migrate` smoke
- `README.md` — Database migrations section + forward-only policy
- `package.json` — adds `better-sqlite3` + `@types/better-sqlite3`, registers `migrate` / `migrate:memory` scripts, allows `better-sqlite3` build script in `pnpm.onlyBuiltDependencies`

## Verification (from the issue)
- [x] applies all migrations from a fresh DB (`runMigrations > applies all migrations from a fresh DB`)
- [x] is idempotent — running twice succeeds (`runMigrations > is idempotent — running twice succeeds`)
- [x] WAL mode is active (`openDb > applies WAL journal_mode (file-backed)`) — `:memory:` forces `journal_mode=memory`, so WAL is verified against a real tempfile
- [x] `synchronous = 1` (NORMAL) (`openDb > applies synchronous=NORMAL (1)`)
- [x] `_migrations` table records applied versions (`runMigrations > creates the _migrations table and records applied versions`)
- [x] Each of the 5 tables has the documented columns + types (`runMigrations > table column checks (vs schema.md) > *`)
- [x] `subtask_instances` UNIQUE INDEX on `claim_token` WHERE `claim_token IS NOT NULL` (`indexes > subtask_instances has a UNIQUE partial index on claim_token`)
- [x] `subtask_instances` INDEX on `(status, created_at)` (`indexes > subtask_instances has an index on (status, created_at)`)
- [x] `agent_actions` INDEX on `(instance_id, ts)` (`indexes > agent_actions has an index on (instance_id, ts)`)
- [x] `pnpm migrate` against `:memory:` exits 0 (`pnpm migrate (end-to-end smoke) > pnpm migrate:memory exits 0`)
- [x] `BEGIN IMMEDIATE` blocks a second `BEGIN IMMEDIATE` on the same DB — DoD (`WAL concurrency: BEGIN IMMEDIATE serializes writers > a second BEGIN IMMEDIATE raises SQLITE_BUSY while the first is open`)
- [x] Schema doc lists every table + column with comments (`src/db/schema.md`)
- [x] README states migrations are forward-only

## Manual checks run locally
- `pnpm typecheck` clean
- `pnpm lint` clean (ESLint + ts-prune)
- `pnpm test` 43/43 tests green (root) + 34/34 (contracts-types)
- `pnpm grep:all` clean (auth equality, timingSafeEqual, accepted-key, secret logging)
- `DATABASE_PATH=/tmp/murmur-verify.db pnpm migrate` then `sqlite3 ... "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"` returns `_migrations`, `agent_actions`, `pipelines`, `runs`, `sqlite_sequence`, `subtask_instances`, `subtask_results` — `sqlite_sequence` is auto-created by SQLite because `agent_actions.id` uses `AUTOINCREMENT`; the issue's expected list was the 5 domain tables + `_migrations`, which match
- `sqlite3 ... ".schema subtask_instances"` matches the SQL in `0001_init.sql` and the doc in `schema.md` exactly
- Re-running `pnpm migrate` against the same file logs `applied:[]`, `skipped:[1]` (idempotency)

## Notes for reviewer
- **Column inference.** DESIGN.md §3.3 names the five tables and a few load-bearing columns (`claim_token`, `expires_at`, `status`, `created_at`) but doesn't enumerate the rest. Columns I added were inferred from §3.1 (pipeline-def shape), §3.2 (publisher API), §3.6 (audit log + truncation), and the contracts-types package. `src/db/schema.md` is the place to push back on individual choices; the SQL must match the doc.
- **`runs.webhook_url` is materialised at run-start** rather than re-resolved from the pipeline def. §3.3 says subcommand endpoints are read live; the webhook URL isn't called out either way, but pinning it at run-start avoids a publisher hot-fix that retargets the webhook mid-run from breaking idempotent delivery. Happy to flip if M11 wants it live-read.
- **`agent_actions.id` uses `AUTOINCREMENT`.** This implicitly creates `sqlite_sequence`. The migrations test query filters `name NOT LIKE 'sqlite_%'`, so the live test passes; the manual issue command (`SELECT name FROM sqlite_master WHERE type='table'`) does include `sqlite_sequence`. Documented this in the manual-check section above.
- **Coverage gate untouched.** Per orchestrator note 6, `src/db/**` isn't in the coverage gate this PR. Tests cover everything (43/43); a follow-up issue can add `src/db/**` to the gate once M3/M4/M11 land their gated paths.
- **Native build.** `better-sqlite3` ships native bindings; `pnpm.onlyBuiltDependencies` was extended to allow them. CI on Linux x64 should pick up prebuilds; if not, the standard Node 22 toolchain (python3 + make) is sufficient to build from source.