### PR TITLE
ci(deploy): GH Actions deploy to Hetzner via SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,92 @@
+# Deploy Murmur to Hetzner. Triggered after CI succeeds on main.
+#
+# Source spec: DESIGN.md §6.3, issue #19.
+#
+# Trigger model:
+#   - `workflow_run`: kicks off after `CI` completes successfully on
+#     `main`. We only deploy what CI built; if CI fails, deploy never
+#     runs (gate inside the job on `conclusion == 'success'`).
+#   - `workflow_dispatch`: manual override so the operator can re-deploy
+#     after secrets-only changes (no code commit) or roll forward.
+#
+# Concurrency: `deploy-main` with `cancel-in-progress: false` — never
+# kill an in-flight deploy mid-restart.
+#
+# Secrets resolve from the `production` environment (DESIGN §6.3).
+# Required: MURMUR_TOKEN, CLOUDFLARE_TUNNEL_TOKEN, HETZNER_SSH_KEY,
+# HETZNER_HOST, GHCR_PAT, OWNER. The CI build job already publishes
+# `ghcr.io/${OWNER}/murmur:latest` — this workflow only ferries the
+# compose file + deploy.sh and triggers a pull on the box.
+#
+# Action SHA pins (mirrors jobseek/apps/crawler deploy):
+#   appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634   # v0.1.7
+#   appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2   # v1
+#   actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd      # v6
+
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # `environment: production` is what makes the production-env secrets
+    # available to this job. Required reviewers/wait-timer rules can be
+    # added later in repo settings without changing this file.
+    environment: production
+    # Gate: only deploy if the upstream CI run succeeded. For
+    # `workflow_dispatch`, `workflow_run` is null so we always proceed.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout (for compose + deploy.sh)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Copy deploy files to box
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: deploy
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          # `source: "a,b"` (comma-separated) per scp-action docs; the
+          # paths are relative to the workspace. `strip_components: 1`
+          # drops the leading `scripts/` so deploy.sh lands at
+          # /home/deploy/deploy.sh (compose stays at /home/deploy/
+          # docker-compose.yml).
+          source: docker-compose.yml,scripts/deploy.sh
+          target: /home/deploy/
+          strip_components: 1
+          # Note: docker-compose.yml at repo root has no leading dir;
+          # scp-action preserves it as-is. strip_components=1 only
+          # affects scripts/deploy.sh (→ deploy.sh on the box).
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: deploy
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          # `envs:` whitelist — only these names are forwarded into the
+          # remote shell. Names only; values come from the matching
+          # `env:` block below. NEVER list a secret name in `script:`.
+          envs: OWNER,GHCR_PAT,MURMUR_TOKEN,CLOUDFLARE_TUNNEL_TOKEN
+          script: bash /home/deploy/deploy.sh
+        env:
+          # `OWNER` is fixed to the GH repo org so the GHCR image path
+          # in docker-compose.yml resolves correctly.
+          OWNER: ${{ github.repository_owner }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          MURMUR_TOKEN: ${{ secrets.MURMUR_TOKEN }}
+          CLOUDFLARE_TUNNEL_TOKEN: ${{ secrets.CLOUDFLARE_TUNNEL_TOKEN }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,11 +37,77 @@
 #   DATABASE_PATH            — defaults to /mnt/murmur/murmur.db inside
 #                              the container; the host mount lives on
 #                              the dedicated volume.
+#
+# Test override:
+#   DEPLOY_DIR — defaults to /home/deploy. Set to a tmp dir by the
+#                vitest harness so unit tests don't touch the real path.
 
 set -euo pipefail
 
-# NOTE: The exit-code 7 sentinel is only used by the test harness to
-# distinguish "stub not implemented" from a real env-var failure (1).
-# It is removed in the implementation step.
-echo "deploy.sh: not implemented" >&2
-exit 7
+# ── Paths ────────────────────────────────────────────────────────────
+# DEPLOY_DIR is the directory holding docker-compose.yml + .env on the
+# box. Tests override this to an isolated tmpdir. The default matches
+# the SCP target in `.github/workflows/deploy.yml`.
+DEPLOY_DIR="${DEPLOY_DIR:-/home/deploy}"
+
+# ── Validate required env vars ───────────────────────────────────────
+# We check for *unset or empty*. The error message lists the missing
+# names but NEVER prints values.
+required_vars=(
+  OWNER
+  GHCR_PAT
+  MURMUR_TOKEN
+  CLOUDFLARE_TUNNEL_TOKEN
+)
+
+missing=()
+for var in "${required_vars[@]}"; do
+  # `${!var:-}` is bash indirect expansion; the `:-` default keeps
+  # `set -u` quiet when the var is unset.
+  if [[ -z "${!var:-}" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: Missing required env vars: ${missing[*]}" >&2
+  exit 1
+fi
+
+# ── Login to GHCR (stdin, never argv) ────────────────────────────────
+# `--password-stdin` keeps the PAT out of `ps` output and shell history.
+# The here-string `<<<` feeds GHCR_PAT into stdin without a temp file.
+docker login ghcr.io --username "$OWNER" --password-stdin <<<"$GHCR_PAT"
+
+# ── Write env file (mode 600) ────────────────────────────────────────
+# umask 077 BEFORE the redirect so the file is created with mode 0600
+# from the start (no race window where it briefly exists at 0644).
+# We restore umask afterwards in case the shell continues with other
+# operations that need group/other read.
+mkdir -p "$DEPLOY_DIR"
+prev_umask=$(umask)
+umask 077
+cat > "$DEPLOY_DIR/.env" <<EOF
+OWNER=${OWNER}
+MURMUR_TOKEN=${MURMUR_TOKEN}
+CLOUDFLARE_TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}
+DATABASE_PATH=${DATABASE_PATH:-/mnt/murmur/murmur.db}
+EOF
+umask "$prev_umask"
+
+# Defence-in-depth: chmod regardless. Cheaper than relying on umask
+# alone if a future edit reorders the writes.
+chmod 600 "$DEPLOY_DIR/.env"
+
+# ── Pull images and restart the stack ────────────────────────────────
+cd "$DEPLOY_DIR"
+docker compose pull
+docker compose up -d --remove-orphans
+
+# ── Run migrations against the live container ────────────────────────
+# `docker compose exec -T` disables TTY allocation (required from a
+# non-interactive SSH session). If migrations fail, `set -e` aborts
+# the deploy with a non-zero exit code.
+docker compose exec -T murmur pnpm migrate
+
+echo "Deploy complete."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/deploy.sh — Hetzner deploy entrypoint, executed on the box by
+# the GH Action `.github/workflows/deploy.yml` over SSH.
+#
+# Source spec: DESIGN.md §6.3 ("Deploy pipeline") and issue #19.
+#
+# Contract:
+#   1. `set -euo pipefail` at the top so any failure aborts the deploy.
+#   2. Validates required env vars; if any are missing, prints the names
+#      (NEVER values) to stderr and exits non-zero.
+#   3. Logs in to GHCR using `--password-stdin` (keeps the PAT off argv).
+#   4. Writes /home/deploy/.env with mode 600 BEFORE writing values
+#      (`umask 077`). The file holds runtime secrets consumed by
+#      docker-compose.yml.
+#   5. `docker compose pull && docker compose up -d --remove-orphans`.
+#   6. Runs `pnpm migrate` inside the running murmur container via
+#      `docker compose exec -T murmur pnpm migrate`. Exits non-zero if
+#      migrations fail (set -e propagates).
+#
+# Idempotence: re-running on the same image digest is a no-op:
+#   - docker compose pull returns cached layers,
+#   - up -d only restarts services whose config or image changed,
+#   - pnpm migrate is no-op if no pending migrations.
+#
+# Recovery: `docker compose down && docker compose up -d` pulls the
+# previous tag from local cache (no rollback registry needed for MVP).
+#
+# Required env vars (set by the SSH action's `envs:` from the
+# `production` GH environment):
+#   OWNER                    — GH org for the GHCR image (also used for
+#                              docker login username)
+#   GHCR_PAT                 — token with `read:packages` scope
+#   MURMUR_TOKEN             — bearer for publishers (DESIGN §3.6)
+#   CLOUDFLARE_TUNNEL_TOKEN  — base64 token from Cloudflare Zero Trust
+#
+# Optional env vars (compose has defaults):
+#   DATABASE_PATH            — defaults to /mnt/murmur/murmur.db inside
+#                              the container; the host mount lives on
+#                              the dedicated volume.
+
+set -euo pipefail
+
+# NOTE: The exit-code 7 sentinel is only used by the test harness to
+# distinguish "stub not implemented" from a real env-var failure (1).
+# It is removed in the implementation step.
+echo "deploy.sh: not implemented" >&2
+exit 7

--- a/test/deploy/deploy-sh.test.ts
+++ b/test/deploy/deploy-sh.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for `scripts/deploy.sh` — the Hetzner deploy entrypoint.
+ *
+ * Strategy: spawn `bash scripts/deploy.sh` with a custom PATH that
+ * shadows `docker` and `pnpm` with shell stubs. The stubs:
+ *   - record their argv to a per-test log file,
+ *   - exit with a configurable code so we can simulate failures.
+ *
+ * This validates the script's behavior end-to-end (env validation,
+ * `.env` mode 600, command order, fail-fast on migrate failure)
+ * without requiring docker / a real box.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const DEPLOY_SH = join(REPO_ROOT, "scripts", "deploy.sh");
+
+interface RunResult {
+  readonly status: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly dockerLog: string;
+  readonly pnpmLog: string;
+  readonly envFile: string | null;
+  readonly envFileMode: number | null;
+}
+
+interface RunOptions {
+  /** Env vars to set in the child shell. */
+  readonly env?: Record<string, string>;
+  /** Override exit codes for stub commands. Default 0. */
+  readonly stubExits?: {
+    readonly docker?: number;
+    readonly dockerExec?: number;
+    readonly pnpm?: number;
+  };
+}
+
+/**
+ * Spawn `bash deploy.sh` with mocked docker/pnpm on PATH, in an
+ * isolated tmp HOME so /home/deploy doesn't get touched. We rebind
+ * `DEPLOY_DIR` via env override (the script reads it).
+ */
+function runDeploy(opts: RunOptions = {}): RunResult {
+  const tmp = mkdtempSync(join(tmpdir(), "murmur-deploy-test-"));
+  const stubDir = join(tmp, "stubs");
+  const deployDir = join(tmp, "deploy");
+  mkdirSync(stubDir, { recursive: true });
+  mkdirSync(deployDir, { recursive: true });
+
+  const dockerLog = join(tmp, "docker.log");
+  const pnpmLog = join(tmp, "pnpm.log");
+
+  const dockerExit = opts.stubExits?.docker ?? 0;
+  const dockerExecExit = opts.stubExits?.dockerExec ?? 0;
+  const pnpmExit = opts.stubExits?.pnpm ?? 0;
+
+  // `docker` stub:
+  //   - logs every invocation to $DOCKER_LOG,
+  //   - on `docker compose exec -T murmur pnpm migrate`, returns
+  //     $DOCKER_EXEC_EXIT (so we can simulate a failing migration),
+  //   - on `docker login`, drains stdin to avoid SIGPIPE,
+  //   - otherwise returns $DOCKER_EXIT.
+  writeFileSync(
+    join(stubDir, "docker"),
+    `#!/usr/bin/env bash
+set -u
+echo "docker $*" >> "$DOCKER_LOG"
+case "$1 \${2:-}" in
+  "login ghcr.io")
+    # Drain stdin so callers using --password-stdin don't SIGPIPE.
+    cat >/dev/null
+    exit "$DOCKER_EXIT"
+    ;;
+esac
+# Detect "compose exec ... pnpm migrate" — on failure, return the
+# configured exit code. This lets us simulate a broken migration.
+if [[ "$1" == "compose" && "$2" == "exec" ]]; then
+  exit "$DOCKER_EXEC_EXIT"
+fi
+exit "$DOCKER_EXIT"
+`,
+    { mode: 0o755 },
+  );
+  // `pnpm` stub — only used if the script ever invoked pnpm directly
+  // (it shouldn't; migrate runs inside the container via compose exec).
+  writeFileSync(
+    join(stubDir, "pnpm"),
+    `#!/usr/bin/env bash
+echo "pnpm $*" >> "$PNPM_LOG"
+exit "$PNPM_EXIT"
+`,
+    { mode: 0o755 },
+  );
+
+  const baseEnv: Record<string, string> = {
+    PATH: `${stubDir}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+    HOME: tmp,
+    DEPLOY_DIR: deployDir,
+    DOCKER_LOG: dockerLog,
+    PNPM_LOG: pnpmLog,
+    DOCKER_EXIT: String(dockerExit),
+    DOCKER_EXEC_EXIT: String(dockerExecExit),
+    PNPM_EXIT: String(pnpmExit),
+    ...(opts.env ?? {}),
+  };
+
+  const result = spawnSync("bash", [DEPLOY_SH], {
+    env: baseEnv,
+    encoding: "utf8",
+  });
+
+  const envPath = join(deployDir, ".env");
+  const envFile = existsSync(envPath) ? readFileSync(envPath, "utf8") : null;
+  const envFileMode = existsSync(envPath) ? statSync(envPath).mode & 0o777 : null;
+  const dockerLogContents = existsSync(dockerLog) ? readFileSync(dockerLog, "utf8") : "";
+  const pnpmLogContents = existsSync(pnpmLog) ? readFileSync(pnpmLog, "utf8") : "";
+
+  // Cleanup tmpdir to avoid leaks across tests.
+  rmSync(tmp, { recursive: true, force: true });
+
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    dockerLog: dockerLogContents,
+    pnpmLog: pnpmLogContents,
+    envFile,
+    envFileMode,
+  };
+}
+
+const VALID_ENV: Record<string, string> = {
+  OWNER: "colophon-group",
+  GHCR_PAT: "test-pat",
+  MURMUR_TOKEN: "test-murmur-token",
+  CLOUDFLARE_TUNNEL_TOKEN: "test-cf-tunnel",
+};
+
+describe("scripts/deploy.sh", () => {
+  it("uses set -euo pipefail at the top", () => {
+    const src = readFileSync(DEPLOY_SH, "utf8");
+    // Allow leading shebang + comments + blank lines, then the safety line.
+    expect(src).toMatch(/^|\nset -euo pipefail\b/);
+    // Stronger: there must be a literal `set -euo pipefail` line.
+    expect(src).toContain("set -euo pipefail");
+  });
+
+  it("fails fast and lists missing env vars when none are set", () => {
+    const r = runDeploy({ env: {} });
+    expect(r.status).not.toBe(0);
+    // Each required var must be named in stderr.
+    for (const name of Object.keys(VALID_ENV)) {
+      expect(r.stderr).toContain(name);
+    }
+    // No values must be printed (we set no values, so this is checking
+    // the script doesn't echo them on success either). The `.env` file
+    // must NOT have been written when validation fails.
+    expect(r.envFile).toBeNull();
+  });
+
+  it("fails fast when only one env var is missing and names exactly that one", () => {
+    const partial = { ...VALID_ENV };
+    delete partial.MURMUR_TOKEN;
+    const r = runDeploy({ env: partial });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("MURMUR_TOKEN");
+    // Must not falsely accuse other vars.
+    expect(r.stderr).not.toContain("OWNER ");
+  });
+
+  it("writes /home/deploy/.env with mode 0600 when all env vars are set", () => {
+    const r = runDeploy({ env: VALID_ENV });
+    expect(r.status).toBe(0);
+    expect(r.envFile).not.toBeNull();
+    expect(r.envFileMode).toBe(0o600);
+  });
+
+  it("writes the expected KEY=VALUE pairs into the env file", () => {
+    const r = runDeploy({ env: VALID_ENV });
+    expect(r.status).toBe(0);
+    const env = r.envFile ?? "";
+    expect(env).toContain(`OWNER=${VALID_ENV.OWNER}`);
+    expect(env).toContain(`MURMUR_TOKEN=${VALID_ENV.MURMUR_TOKEN}`);
+    expect(env).toContain(`CLOUDFLARE_TUNNEL_TOKEN=${VALID_ENV.CLOUDFLARE_TUNNEL_TOKEN}`);
+  });
+
+  it("does NOT write the GHCR_PAT into the env file (only docker login uses it)", () => {
+    const r = runDeploy({ env: VALID_ENV });
+    expect(r.status).toBe(0);
+    expect(r.envFile ?? "").not.toContain(VALID_ENV.GHCR_PAT);
+  });
+
+  it("invokes docker compose pull then up -d --remove-orphans then exec pnpm migrate, in that order", () => {
+    const r = runDeploy({ env: VALID_ENV });
+    expect(r.status).toBe(0);
+    const log = r.dockerLog;
+    const idxPull = log.indexOf("docker compose pull");
+    const idxUp = log.indexOf("docker compose up -d --remove-orphans");
+    const idxMigrate = log.indexOf("docker compose exec -T murmur pnpm migrate");
+    expect(idxPull).toBeGreaterThanOrEqual(0);
+    expect(idxUp).toBeGreaterThan(idxPull);
+    expect(idxMigrate).toBeGreaterThan(idxUp);
+  });
+
+  it("logs in to GHCR via stdin (no PAT on argv)", () => {
+    const r = runDeploy({ env: VALID_ENV });
+    expect(r.status).toBe(0);
+    // Must reference `--password-stdin` and must NOT contain the PAT.
+    expect(r.dockerLog).toContain("login ghcr.io");
+    expect(r.dockerLog).toContain("--password-stdin");
+    expect(r.dockerLog).not.toContain(VALID_ENV.GHCR_PAT);
+  });
+
+  it("exits non-zero when the migration step fails (set -e propagates)", () => {
+    const r = runDeploy({ env: VALID_ENV, stubExits: { dockerExec: 1 } });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("exits non-zero when docker compose pull fails", () => {
+    const r = runDeploy({ env: VALID_ENV, stubExits: { docker: 2 } });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("is idempotent on a second invocation with no changes", () => {
+    // Two consecutive runs against the same VALID_ENV should both
+    // succeed; the second is effectively the no-op case (docker stubs
+    // simulate cached pull → exit 0; up -d no-op → exit 0).
+    const r1 = runDeploy({ env: VALID_ENV });
+    const r2 = runDeploy({ env: VALID_ENV });
+    expect(r1.status).toBe(0);
+    expect(r2.status).toBe(0);
+  });
+});
+
+describe(".github/workflows/deploy.yml", () => {
+  const WORKFLOW = join(REPO_ROOT, ".github", "workflows", "deploy.yml");
+
+  it("exists", () => {
+    expect(existsSync(WORKFLOW)).toBe(true);
+  });
+
+  it("pins appleboy/scp-action to a SHA, not a tag", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    // Match `appleboy/scp-action@<40 hex chars>`. Reject tag-style refs.
+    expect(src).toMatch(/appleboy\/scp-action@[0-9a-f]{40}\b/);
+    expect(src).not.toMatch(/appleboy\/scp-action@v[0-9]/);
+  });
+
+  it("pins appleboy/ssh-action to a SHA, not a tag", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).toMatch(/appleboy\/ssh-action@[0-9a-f]{40}\b/);
+    expect(src).not.toMatch(/appleboy\/ssh-action@v[0-9]/);
+  });
+
+  it("declares a concurrency group keyed on deploy-main with cancel-in-progress disabled", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).toMatch(/group:\s*deploy-main/);
+    expect(src).toMatch(/cancel-in-progress:\s*false/);
+  });
+
+  it("uses environment: production so secrets resolve from the prod env", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).toMatch(/environment:\s*production/);
+  });
+
+  it("triggers on workflow_run after CI completes and supports manual dispatch", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).toMatch(/workflow_run:/);
+    expect(src).toMatch(/workflows:\s*\["CI"\]/);
+    expect(src).toMatch(/workflow_dispatch:/);
+  });
+
+  it("gates the deploy job on workflow_run.conclusion == 'success' or workflow_dispatch", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    expect(src).toContain("workflow_run.conclusion == 'success'");
+    expect(src).toContain("workflow_dispatch");
+  });
+
+  it("never echoes a secret value in script: blocks (only names in envs:)", () => {
+    const src = readFileSync(WORKFLOW, "utf8");
+    // Disallow naive `echo "$SECRET_*"` or `echo $secrets.*` patterns.
+    expect(src).not.toMatch(/echo\s+"\$\{?secrets\./i);
+    expect(src).not.toMatch(/printenv\s/);
+  });
+});

--- a/test/deploy/deploy-sh.test.ts
+++ b/test/deploy/deploy-sh.test.ts
@@ -11,12 +11,12 @@
  * without requiring docker / a real box.
  */
 
-import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync, chmodSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, statSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const REPO_ROOT = resolve(__dirname, "..", "..");
 const DEPLOY_SH = join(REPO_ROOT, "scripts", "deploy.sh");


### PR DESCRIPTION
## Summary

Adds the D2 deploy pipeline: a `Deploy` workflow that runs after `CI` succeeds on `main`, SCPs `docker-compose.yml` + `scripts/deploy.sh` to the Hetzner box, and SSHes in to run `bash deploy.sh`. The deploy script validates required env vars, writes `/home/deploy/.env` with mode 0600, logs in to GHCR via `--password-stdin`, pulls the latest image, brings up the stack, and runs `pnpm migrate` inside the running murmur container.

## Related issue
Closes colophon-group/murmur#19

## Files changed (high-level)
- `.github/workflows/deploy.yml` — new; `workflow_run` trigger after `CI` + `workflow_dispatch`; `environment: production`; SCP + SSH actions SHA-pinned; concurrency group `deploy-main` with `cancel-in-progress: false`.
- `scripts/deploy.sh` — new, executable; `set -euo pipefail`; env validation; `.env` written under `umask 077` and chmod 600; GHCR login via stdin; `docker compose pull && up -d --remove-orphans`; `docker compose exec -T murmur pnpm migrate`.
- `test/deploy/deploy-sh.test.ts` — new; vitest harness that spawns `bash scripts/deploy.sh` with stub `docker`/`pnpm` on PATH, asserting env validation, `.env` mode 0600, command order, fail-fast on migration error, idempotence, and workflow-yml properties (SHA pins, concurrency, environment, gate).

## Verification (from the issue)

**deploy.sh:**
- [x] `set -euo pipefail` at top
- [x] Validates required env vars; lists missing ones; never prints values
- [x] `.env` written with mode 0600 (umask 077 + explicit chmod)
- [x] Migrations run after `docker compose up`, against the live container
- [x] Idempotent: second run with no changes is a no-op
- [x] Fails fast if migration step exits non-zero (set -e)

**Workflow:**
- [x] Triggered on `workflow_run` after `CI` succeeds on `main` (gate inside job on `conclusion == 'success'`)
- [x] `workflow_dispatch` for manual operator-driven re-deploys
- [x] `appleboy/scp-action` and `appleboy/ssh-action` SHA-pinned (reused from jobseek's deploy: scp v0.1.7 SHA `917f8b81…`, ssh v1 SHA `0ff4204d…`)
- [x] `actions/checkout` SHA-pinned (`de0fac2e…` v6)
- [x] Concurrency group `deploy-main`, `cancel-in-progress: false`
- [x] Job uses `environment: production` so secrets resolve from the prod env
- [x] No secret printed in workflow logs (only secret *names* in `envs:`; values forwarded via `env:` block)

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (104/104 vitest, 34/34 contracts-types)
- `pnpm grep:all` ✓
- `python3 -c 'yaml.safe_load(...)'` ✓ (workflow YAML parses)

## Live verification — deferred to operator

Per the orchestrator note (same pattern as D3/D4), the workflow is NOT executed against the real Hetzner box from this PR. The operator must:

1. Populate the GH `production` environment with secrets:
   `MURMUR_TOKEN`, `CLOUDFLARE_TUNNEL_TOKEN`, `HETZNER_SSH_KEY`, `HETZNER_HOST`, `GHCR_PAT`.
   (`OWNER` is taken from `github.repository_owner` automatically.)
2. Land this PR + push a no-op commit on `main` to fire `CI` → `Deploy`.
3. Confirm: `curl https://murmur.colophon-group.org/health` → 200; `docker compose logs murmur --tail 20` shows clean boot.
4. Optional smoke for fail-fast: introduce a deliberately broken migration on a branch, deploy, confirm the workflow exits non-zero before the stack is left in a bad state.

## Notes for reviewer
- `DEPLOY_DIR` is overrideable (defaults to `/home/deploy`) so the vitest harness can drive the script in an isolated tmpdir without touching real paths.
- The `.env` written by `deploy.sh` is a strict subset of compose-required keys: `OWNER`, `MURMUR_TOKEN`, `CLOUDFLARE_TUNNEL_TOKEN`, `DATABASE_PATH`. `GHCR_PAT` is intentionally NOT written to the file — it's only consumed once for `docker login`.
- The action SHA pins are reused 1:1 from jobseek's `deploy-crawler-browser.yml`, which has been running in production. If the reviewer prefers fresher SHAs we can bump in a follow-up.
- The trigger model (`workflow_run` from `ci.yml`) means the very first run of `Deploy` happens on the merge of *the next* commit to main after this PR lands, not this PR itself — that's intentional, since CI on this PR runs in a pull_request context and won't fire `workflow_run` on main.