### PR TITLE
feat(api): publisher endpoints — pipelines + runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@murmur/contracts-types": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "better-sqlite3": "^12.9.0"
+    "better-sqlite3": "^12.9.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
@@ -1624,6 +1627,11 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3053,5 +3061,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}

--- a/src/api/publisher/ids.test.ts
+++ b/src/api/publisher/ids.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { newInstanceId, newRunId } from "./ids.js";
+
+describe("newRunId", () => {
+  it("returns a string of the form r_<hex>", () => {
+    const id = newRunId();
+    expect(id).toMatch(/^r_[0-9a-f]{20,}$/);
+  });
+
+  it("is distinct across consecutive calls", () => {
+    expect(newRunId()).not.toBe(newRunId());
+  });
+});
+
+describe("newInstanceId", () => {
+  it("returns a string of the form i_<hex>", () => {
+    const id = newInstanceId();
+    expect(id).toMatch(/^i_[0-9a-f]{20,}$/);
+  });
+
+  it("is distinct across consecutive calls", () => {
+    expect(newInstanceId()).not.toBe(newInstanceId());
+  });
+});

--- a/src/api/publisher/ids.ts
+++ b/src/api/publisher/ids.ts
@@ -9,6 +9,15 @@
  * @see DESIGN.md §3.6 — webhook idempotency keys are run ids
  */
 
+import { randomBytes } from "node:crypto";
+
+/**
+ * Width in bytes of the random suffix appended to each id. 12 bytes
+ * (96 bits) hex-encodes to 24 chars and is well above the demo-grade
+ * collision-resistance bar.
+ */
+const ID_RANDOM_BYTES = 12;
+
 /**
  * Mint a new run id of the form `r_<24 hex chars>` (96 bits of entropy).
  *
@@ -16,7 +25,7 @@
  *   width.
  */
 export function newRunId(): string {
-  throw new Error("not implemented");
+  return `r_${randomBytes(ID_RANDOM_BYTES).toString("hex")}`;
 }
 
 /**
@@ -25,5 +34,5 @@ export function newRunId(): string {
  * @returns a fresh instance id.
  */
 export function newInstanceId(): string {
-  throw new Error("not implemented");
+  return `i_${randomBytes(ID_RANDOM_BYTES).toString("hex")}`;
 }

--- a/src/api/publisher/ids.ts
+++ b/src/api/publisher/ids.ts
@@ -1,0 +1,29 @@
+/**
+ * Opaque-id generators for runs and subtask instances.
+ *
+ * Identifiers are caller-generated random strings (hex-encoded random
+ * bytes) — the schema treats them as opaque (`TEXT NOT NULL`); see
+ * `src/db/schema.md`. Prefixes (`r_`, `i_`) keep them visually distinct
+ * in logs and in the `Idempotency-Key` header for webhook delivery.
+ *
+ * @see DESIGN.md §3.6 — webhook idempotency keys are run ids
+ */
+
+/**
+ * Mint a new run id of the form `r_<24 hex chars>` (96 bits of entropy).
+ *
+ * @returns a fresh run id; collisions are statistically negligible at this
+ *   width.
+ */
+export function newRunId(): string {
+  throw new Error("not implemented");
+}
+
+/**
+ * Mint a new subtask-instance id of the form `i_<24 hex chars>`.
+ *
+ * @returns a fresh instance id.
+ */
+export function newInstanceId(): string {
+  throw new Error("not implemented");
+}

--- a/src/api/publisher/index.ts
+++ b/src/api/publisher/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Publisher sub-app — three publisher-facing endpoints.
+ *
+ * Routes (DESIGN.md §3.2):
+ *   - `POST /pipelines`               — register/upsert a pipeline def.
+ *   - `POST /pipelines/{id}/runs`     — start a run.
+ *   - `GET  /runs/{run_id}`           — poll run state + audit log.
+ *
+ * The sub-app is mounted by `src/server.ts`. All three routes inherit
+ * the bearer-auth middleware installed at the root of the main app
+ * (`/health` is the only carve-out). This module's factory does NOT
+ * install auth itself — composing auth twice would be wrong.
+ *
+ * The factory takes a `db` handle by injection so the same code is
+ * exercisable in tests with `:memory:` and in production with a
+ * file-backed DB. There is no module-level singleton.
+ */
+
+import type Database from "better-sqlite3";
+import { Hono } from "hono";
+
+/**
+ * Options accepted by {@link createPublisherApp}.
+ */
+export interface CreatePublisherAppOptions {
+  /**
+   * Open SQLite handle. The handle is borrowed — callers retain ownership
+   * and are responsible for closing it. Migrations MUST have been run on
+   * this handle before any request hits the sub-app; the sub-app does
+   * not run migrations itself.
+   */
+  readonly db: Database.Database;
+}
+
+/**
+ * Build the publisher sub-app.
+ *
+ * @param options see {@link CreatePublisherAppOptions}.
+ * @returns a Hono instance with the three routes registered. Mount it
+ *   onto the main app with `app.route("/", publisherApp)` (the routes
+ *   carry their own absolute-style paths under `/`).
+ */
+export function createPublisherApp(options: CreatePublisherAppOptions): Hono {
+  // Sub-app composition; the actual route bodies live in the sibling
+  // modules. Each `mount*` function attaches its routes to this Hono
+  // instance.
+  const app = new Hono();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- wired by mount fns once interfaces are filled in
+  const _db = options.db;
+  // Implementations land in step 6.
+  return app;
+}

--- a/src/api/publisher/index.ts
+++ b/src/api/publisher/index.ts
@@ -19,6 +19,9 @@
 import type Database from "better-sqlite3";
 import { Hono } from "hono";
 
+import { mountPipelineRoutes } from "./pipelines.js";
+import { mountRunRoutes } from "./runs.js";
+
 /**
  * Options accepted by {@link createPublisherApp}.
  */
@@ -41,12 +44,8 @@ export interface CreatePublisherAppOptions {
  *   carry their own absolute-style paths under `/`).
  */
 export function createPublisherApp(options: CreatePublisherAppOptions): Hono {
-  // Sub-app composition; the actual route bodies live in the sibling
-  // modules. Each `mount*` function attaches its routes to this Hono
-  // instance.
   const app = new Hono();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- wired by mount fns once interfaces are filled in
-  const _db = options.db;
-  // Implementations land in step 6.
+  mountPipelineRoutes(app, options.db);
+  mountRunRoutes(app, options.db);
   return app;
 }

--- a/src/api/publisher/pipelines.ts
+++ b/src/api/publisher/pipelines.ts
@@ -1,0 +1,49 @@
+/**
+ * `POST /pipelines` and `POST /pipelines/{id}/runs` route handlers.
+ *
+ * These mount onto the publisher sub-app from `./index.ts`. Both routes
+ * sit behind the bearer-auth middleware installed in `src/server.ts`;
+ * this module assumes auth has already passed when its handlers run.
+ *
+ * @see DESIGN.md §3.2 — POST /pipelines, POST /pipelines/{id}/runs
+ */
+
+import type Database from "better-sqlite3";
+import type { Hono } from "hono";
+
+/**
+ * Maximum body size accepted by `POST /pipelines`. Anything larger is
+ * rejected with `413 { ok: false, errors: ["payload_too_large"] }` BEFORE
+ * the body is parsed as YAML — both to short-circuit obvious abuse and
+ * to keep the YAML parser from chewing through pathological inputs.
+ */
+export const PIPELINE_BODY_BYTE_CAP = 5 * 1024 * 1024;
+
+/**
+ * Mount the pipeline-registration and run-creation routes onto the given
+ * Hono sub-app.
+ *
+ * Routes registered (relative to the sub-app's mount point):
+ *   - `POST /pipelines` — register/upsert a pipeline def.
+ *     • body: `{ id, def_yaml }` (`def_yaml` is a YAML string).
+ *     • 200 `{ ok: true, data: { id } }` on success.
+ *     • 400 `{ ok: false, errors: ["yaml:<msg>"] }` on YAML parse failure.
+ *     • 400 `{ ok: false, errors: ["validation:/path:msg", ...] }` on
+ *       JSON Schema shape failures (one per offending path).
+ *     • 413 `{ ok: false, errors: ["payload_too_large"] }` on >5 MB.
+ *     • Last-write-wins on `id` collision (UPSERT, version bumped).
+ *
+ *   - `POST /pipelines/{id}/runs` — start a run.
+ *     • body: `{ initial_input }`.
+ *     • 200 `{ ok: true, data: { run_id } }` on success.
+ *     • 404 `{ ok: false, errors: ["pipeline_not_found"] }` if `id` is
+ *       unknown.
+ *     • 400 `{ ok: false, errors: ["validation:/path:msg", ...] }` if
+ *       `initial_input` fails the pipeline's `initial_input` schema.
+ *
+ * @param app the sub-app to mount onto (the publisher Hono).
+ * @param db the open SQLite handle (from `openDb`).
+ */
+export function mountPipelineRoutes(app: Hono, db: Database.Database): void {
+  throw new Error("not implemented");
+}

--- a/src/api/publisher/pipelines.ts
+++ b/src/api/publisher/pipelines.ts
@@ -10,6 +10,17 @@
 
 import type Database from "better-sqlite3";
 import type { Hono } from "hono";
+import { parse as parseYaml, YAMLParseError } from "yaml";
+
+import type { Err, Ok, PipelineDef } from "@murmur/contracts-types";
+
+import {
+  validateAgainst,
+  validateJsonSchema,
+} from "../../dispatch/validation.js";
+import { newInstanceId, newRunId } from "./ids.js";
+import { computeReadySet } from "./ready_set.js";
+import { PIPELINE_DEF_SCHEMA } from "./schema.js";
 
 /**
  * Maximum body size accepted by `POST /pipelines`. Anything larger is
@@ -19,31 +30,272 @@ import type { Hono } from "hono";
  */
 export const PIPELINE_BODY_BYTE_CAP = 5 * 1024 * 1024;
 
+/** Shape of the `POST /pipelines` request body. */
+interface PostPipelinesBody {
+  readonly id?: unknown;
+  readonly def_yaml?: unknown;
+}
+
+/** Shape of the `POST /pipelines/{id}/runs` request body. */
+interface PostRunsBody {
+  readonly initial_input?: unknown;
+}
+
+/**
+ * Walk a pipeline-def's schema-bearing fields and confirm each is a
+ * structurally valid JSON Schema (compiles under Ajv `strict: true`).
+ *
+ * The outer `pipeline-def.schema.json` only asserts each schema slot is
+ * a JSON object — it does NOT compile the inner schemas. We do that
+ * here so a typo like `requried:` is caught at registration, not at
+ * the first runtime validation.
+ *
+ * @returns an array of `validation:<path>:<msg>` strings; empty when
+ *   every inner schema is well-formed.
+ */
+function validateInnerSchemas(def: PipelineDef): ReadonlyArray<string> {
+  const errors: string[] = [];
+
+  // initial_input — top-level schema for `POST /pipelines/{id}/runs`.
+  const initialResult = validateJsonSchema(def.initial_input);
+  if (!initialResult.ok) {
+    errors.push(`validation:/initial_input${initialResult.error.startsWith(":") ? "" : ":"}${initialResult.error}`);
+  }
+
+  for (let i = 0; i < def.subtasks.length; i++) {
+    const sub = def.subtasks[i];
+    if (sub === undefined) continue;
+    const outResult = validateJsonSchema(sub.output_schema);
+    if (!outResult.ok) {
+      errors.push(
+        `validation:/subtasks/${i}/output_schema${outResult.error.startsWith(":") ? "" : ":"}${outResult.error}`,
+      );
+    }
+    const subcommands = sub.subcommands ?? [];
+    for (let j = 0; j < subcommands.length; j++) {
+      const cmd = subcommands[j];
+      if (cmd === undefined) continue;
+      if (cmd.input_schema !== undefined) {
+        const r = validateJsonSchema(cmd.input_schema);
+        if (!r.ok) {
+          errors.push(
+            `validation:/subtasks/${i}/subcommands/${j}/input_schema${r.error.startsWith(":") ? "" : ":"}${r.error}`,
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+/**
+ * Build a `400 Err` response body for a list of pre-formatted error
+ * tokens. Centralised so every reject path on this surface emits the
+ * exact same envelope shape.
+ */
+function badRequest(errors: ReadonlyArray<string>): Err {
+  return { ok: false, errors };
+}
+
 /**
  * Mount the pipeline-registration and run-creation routes onto the given
  * Hono sub-app.
  *
  * Routes registered (relative to the sub-app's mount point):
  *   - `POST /pipelines` — register/upsert a pipeline def.
- *     • body: `{ id, def_yaml }` (`def_yaml` is a YAML string).
- *     • 200 `{ ok: true, data: { id } }` on success.
- *     • 400 `{ ok: false, errors: ["yaml:<msg>"] }` on YAML parse failure.
- *     • 400 `{ ok: false, errors: ["validation:/path:msg", ...] }` on
- *       JSON Schema shape failures (one per offending path).
- *     • 413 `{ ok: false, errors: ["payload_too_large"] }` on >5 MB.
- *     • Last-write-wins on `id` collision (UPSERT, version bumped).
- *
  *   - `POST /pipelines/{id}/runs` — start a run.
- *     • body: `{ initial_input }`.
- *     • 200 `{ ok: true, data: { run_id } }` on success.
- *     • 404 `{ ok: false, errors: ["pipeline_not_found"] }` if `id` is
- *       unknown.
- *     • 400 `{ ok: false, errors: ["validation:/path:msg", ...] }` if
- *       `initial_input` fails the pipeline's `initial_input` schema.
  *
  * @param app the sub-app to mount onto (the publisher Hono).
  * @param db the open SQLite handle (from `openDb`).
  */
 export function mountPipelineRoutes(app: Hono, db: Database.Database): void {
-  throw new Error("not implemented");
+  // Prepared statements — better-sqlite3 lets us reuse them across
+  // requests for free. They're scoped to this module and hold no
+  // per-request state.
+  const upsertPipeline = db.prepare(
+    `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+       VALUES (@id, 1, @def_json, @now, @now)
+     ON CONFLICT(id) DO UPDATE SET
+       version = pipelines.version + 1,
+       def_json = excluded.def_json,
+       updated_at = excluded.updated_at`,
+  );
+  const selectPipeline = db.prepare(
+    `SELECT id, version, def_json FROM pipelines WHERE id = ?`,
+  );
+  const insertRun = db.prepare(
+    `INSERT INTO runs (
+       id, pipeline_id, pipeline_version, status, initial_input_json,
+       webhook_url, created_at
+     ) VALUES (
+       @id, @pipeline_id, @pipeline_version, 'running', @initial_input_json,
+       @webhook_url, @now
+     )`,
+  );
+  const insertInstance = db.prepare(
+    `INSERT INTO subtask_instances (
+       id, run_id, subtask_id, status, input_json, created_at, updated_at
+     ) VALUES (
+       @id, @run_id, @subtask_id, @status, @input_json, @created_at, @updated_at
+     )`,
+  );
+
+  // POST /pipelines
+  app.post("/pipelines", async (c) => {
+    // 1. Body cap. Hono parses the body lazily; we read raw bytes once
+    //    and gate on length BEFORE asking for `c.req.json()` so a 6 MB
+    //    body never makes it to the JSON parser.
+    let raw: ArrayBuffer;
+    try {
+      raw = await c.req.arrayBuffer();
+    } catch {
+      return c.json(badRequest(["body_unreadable"]), 400);
+    }
+    if (raw.byteLength > PIPELINE_BODY_BYTE_CAP) {
+      return c.json(badRequest(["payload_too_large"]), 413);
+    }
+
+    // 2. Parse JSON wrapper.
+    let body: PostPipelinesBody;
+    try {
+      const text = new TextDecoder("utf-8", { fatal: false }).decode(raw);
+      body = JSON.parse(text) as PostPipelinesBody;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return c.json(badRequest([`json:${msg}`]), 400);
+    }
+    if (typeof body !== "object" || body === null) {
+      return c.json(badRequest(["body must be a JSON object"]), 400);
+    }
+    const defYamlRaw = body.def_yaml;
+    if (typeof defYamlRaw !== "string" || defYamlRaw.length === 0) {
+      return c.json(badRequest(["def_yaml must be a non-empty string"]), 400);
+    }
+
+    // 3. Parse YAML.
+    let parsedDef: unknown;
+    try {
+      parsedDef = parseYaml(defYamlRaw);
+    } catch (err) {
+      const msg =
+        err instanceof YAMLParseError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return c.json(badRequest([`yaml:${msg}`]), 400);
+    }
+    if (
+      parsedDef === null ||
+      typeof parsedDef !== "object" ||
+      Array.isArray(parsedDef)
+    ) {
+      return c.json(badRequest(["yaml: parsed value must be a JSON object"]), 400);
+    }
+
+    // 4. Validate against the M0 pipeline-def schema.
+    const outerResult = validateAgainst<PipelineDef>(
+      PIPELINE_DEF_SCHEMA,
+      parsedDef,
+    );
+    if (!outerResult.ok) {
+      return c.json(badRequest(outerResult.errors), 400);
+    }
+    const def = outerResult.value;
+
+    // 5. Inner-schema validation: each `output_schema`, each
+    //    subcommand's `input_schema`, plus `initial_input`, must
+    //    compile as a standalone JSON Schema (catches `requried:` typos
+    //    and similar).
+    const innerErrors = validateInnerSchemas(def);
+    if (innerErrors.length > 0) {
+      return c.json(badRequest(innerErrors), 400);
+    }
+
+    // 6. Persist (UPSERT — last-write-wins).
+    const now = new Date().toISOString();
+    upsertPipeline.run({
+      id: def.id,
+      def_json: JSON.stringify(def),
+      now,
+    });
+
+    const ok: Ok<{ id: string }> = { ok: true, data: { id: def.id } };
+    return c.json(ok, 200);
+  });
+
+  // POST /pipelines/{id}/runs
+  app.post("/pipelines/:id/runs", async (c) => {
+    const pipelineId = c.req.param("id");
+    if (pipelineId === undefined || pipelineId === "") {
+      return c.json(badRequest(["pipeline_id_required"]), 400);
+    }
+
+    let body: PostRunsBody;
+    try {
+      body = (await c.req.json()) as PostRunsBody;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return c.json(badRequest([`json:${msg}`]), 400);
+    }
+    if (typeof body !== "object" || body === null) {
+      return c.json(badRequest(["body must be a JSON object"]), 400);
+    }
+
+    // Pipeline lookup — 404 on miss.
+    const row = selectPipeline.get(pipelineId) as
+      | { id: string; version: number; def_json: string }
+      | undefined;
+    if (row === undefined) {
+      const err: Err = { ok: false, errors: ["pipeline_not_found"] };
+      return c.json(err, 404);
+    }
+    const def = JSON.parse(row.def_json) as PipelineDef;
+
+    // Validate initial_input against the pipeline's `initial_input`
+    // schema — we already proved at registration that it's a valid
+    // JSON Schema.
+    const initialResult = validateAgainst(def.initial_input, body.initial_input);
+    if (!initialResult.ok) {
+      return c.json(badRequest(initialResult.errors), 400);
+    }
+
+    // Compute ready set + assemble row inserts. Wrap in a transaction so
+    // a partial failure leaves no run/instance rows behind.
+    const runId = newRunId();
+    const now = new Date().toISOString();
+    const readyRows = computeReadySet(
+      def,
+      runId,
+      body.initial_input,
+      now,
+      newInstanceId,
+    );
+
+    const tx = db.transaction(() => {
+      insertRun.run({
+        id: runId,
+        pipeline_id: def.id,
+        pipeline_version: row.version,
+        initial_input_json: JSON.stringify(body.initial_input),
+        webhook_url: def.final_output.webhook,
+        now,
+      });
+      for (const r of readyRows) {
+        insertInstance.run({
+          id: r.id,
+          run_id: r.run_id,
+          subtask_id: r.subtask_id,
+          status: r.status,
+          input_json: r.input_json,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
+        });
+      }
+    });
+    tx();
+
+    const ok: Ok<{ run_id: string }> = { ok: true, data: { run_id: runId } };
+    return c.json(ok, 200);
+  });
 }

--- a/src/api/publisher/publisher.test.ts
+++ b/src/api/publisher/publisher.test.ts
@@ -1,0 +1,564 @@
+/**
+ * Publisher API tests — `POST /pipelines`, `POST /pipelines/{id}/runs`,
+ * `GET /runs/{run_id}`.
+ *
+ * Tests are driven through `app.request(...)` against a `createServer`
+ * built with an in-memory SQLite (migrations applied at the start of
+ * each test). The bearer token is the same constant across all tests,
+ * applied via the `Authorization` header — auth is M3's responsibility,
+ * but at least one test asserts the publisher routes inherit it.
+ */
+
+import Database from "better-sqlite3";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+import { runMigrations } from "../../db/migrate.js";
+import { createServer } from "../../server.js";
+
+// --- Test fixtures -----------------------------------------------------
+
+const TEST_TOKEN = "test-murmur-token-secret";
+const TEST_TOKEN_BUF = Buffer.from(TEST_TOKEN, "utf8");
+const AUTH_HEADERS = { Authorization: `Bearer ${TEST_TOKEN}` };
+
+/**
+ * Minimum-viable valid pipeline def YAML, used as the green-path input
+ * for `POST /pipelines`. Mirrors the §3.1 example shape but trimmed to
+ * the fields required by the M0 schema.
+ *
+ * Note YAML's special handling of `*` — wildcard-prefix and wildcard
+ * compose rules are quoted explicitly here so the YAML parser doesn't
+ * interpret them as anchors.
+ */
+const VALID_PIPELINE_YAML = `
+id: jobseek-add-company
+initial_input:
+  type: object
+  required: [company_name, website]
+  properties:
+    company_name: { type: string, minLength: 1 }
+    website: { type: string, format: uri }
+subtasks:
+  - id: pre-verify
+    instructions: |
+      Confirm the company exists.
+    output_schema:
+      type: object
+      required: [verified]
+      properties:
+        verified: { type: boolean }
+  - id: setup-metadata
+    instructions: Pick metadata.
+    requires: [pre-verify]
+    output_schema:
+      type: object
+      required: [slug]
+      properties:
+        slug: { type: string }
+  - id: list-boards
+    instructions: Discover boards.
+    requires: [pre-verify]
+    output_schema:
+      type: object
+      required: [boards]
+      properties:
+        boards: { type: array }
+    spawns: { for_each: boards, template: configure-board }
+  - id: configure-board
+    instructions: Per-board config.
+    output_schema:
+      type: object
+      required: [outcome]
+      properties:
+        outcome: { enum: [configured, blocked] }
+final_output:
+  composes:
+    - "pre-verify.*"
+    - "setup-metadata.*"
+  webhook: https://example.com/webhook
+`;
+
+/**
+ * Build a fresh in-memory DB with migrations applied + a server bound
+ * to it. Returned together so tests can both make HTTP calls and
+ * inspect the underlying tables.
+ */
+function freshServer(): {
+  db: Database.Database;
+  app: ReturnType<typeof createServer>;
+} {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  // Migrations live under `src/db/migrations/`; the migrate runner
+  // resolves relative to `process.cwd()`, which under vitest is the
+  // package root. That matches the directory layout in `package.json`.
+  runMigrations(db);
+  const app = createServer({ token: TEST_TOKEN_BUF, db });
+  return { db, app };
+}
+
+// --- POST /pipelines ---------------------------------------------------
+
+describe("POST /pipelines", () => {
+  let server: ReturnType<typeof freshServer>;
+  beforeEach(() => {
+    server = freshServer();
+  });
+
+  it("with valid YAML returns 200 { id }", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "jobseek-add-company",
+        def_yaml: VALID_PIPELINE_YAML,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as EnvelopeResponse<{ id: string }>;
+    expect(body).toEqual({ ok: true, data: { id: "jobseek-add-company" } });
+
+    // Persisted to the DB.
+    const row = server.db
+      .prepare("SELECT id, version FROM pipelines WHERE id = ?")
+      .get("jobseek-add-company") as { id: string; version: number };
+    expect(row).toBeDefined();
+    expect(row.id).toBe("jobseek-add-company");
+    expect(row.version).toBe(1);
+  });
+
+  it("with malformed YAML returns 400 with parse error", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "broken",
+        // Unclosed bracket — YAML parse failure.
+        def_yaml: "id: broken\nsubtasks: [unclosed",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      expect(body.errors.length).toBeGreaterThan(0);
+      // First error should reference YAML parsing.
+      const first = body.errors[0];
+      expect(typeof first === "string" && first.startsWith("yaml:")).toBe(true);
+    }
+  });
+
+  it("with invalid pipeline-shape JSON Schema returns 400 with schema-error path", async () => {
+    // Missing required `final_output` triggers a schema-shape failure
+    // against `docs/contracts/pipeline-def.schema.json`.
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "no-final-output",
+        def_yaml:
+          "id: no-final-output\ninitial_input: { type: object }\nsubtasks: [{ id: x, instructions: y, output_schema: { type: object } }]",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      // Every entry should be a `validation:<path>:<msg>` token.
+      expect(body.errors.length).toBeGreaterThan(0);
+      for (const err of body.errors) {
+        expect(typeof err === "string" && err.startsWith("validation:")).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("with an inner JSON Schema that is itself malformed returns 400 with schema-error path", async () => {
+    // `output_schema` here uses an unknown keyword `requried` (typo); the
+    // pipeline def shape passes the outer schema, but our deeper
+    // `validateJsonSchema` walk catches the malformed inner schema.
+    const yaml = `
+id: typo-pipeline
+initial_input: { type: object }
+subtasks:
+  - id: a
+    instructions: x
+    output_schema:
+      type: object
+      requried: [foo]
+final_output:
+  composes: ["a.*"]
+  webhook: https://example.com/webhook
+`;
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "typo-pipeline", def_yaml: yaml }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      // At least one error references a path beneath a subtask's schema.
+      const joined = body.errors.map((e) => (typeof e === "string" ? e : ""))
+        .join("\n");
+      expect(joined).toMatch(/^validation:/m);
+    }
+  });
+
+  it("twice with same id - second one wins (last-write)", async () => {
+    const first = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "jobseek-add-company",
+        def_yaml: VALID_PIPELINE_YAML,
+      }),
+    });
+    expect(first.status).toBe(200);
+
+    // Second upsert: change the webhook so we can verify the new def_json
+    // landed.
+    const updated = VALID_PIPELINE_YAML.replace(
+      "https://example.com/webhook",
+      "https://example.com/webhook2",
+    );
+    const second = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "jobseek-add-company",
+        def_yaml: updated,
+      }),
+    });
+    expect(second.status).toBe(200);
+
+    const row = server.db
+      .prepare("SELECT version, def_json FROM pipelines WHERE id = ?")
+      .get("jobseek-add-company") as { version: number; def_json: string };
+    expect(row.version).toBe(2);
+    const def = JSON.parse(row.def_json) as { final_output: { webhook: string } };
+    expect(def.final_output.webhook).toBe("https://example.com/webhook2");
+  });
+
+  it("rejects bodies above the 5 MB cap with 413", async () => {
+    // 5 MB + a bit. Use a deterministic filler that's valid YAML so a
+    // permissive size check followed by parsing doesn't accidentally
+    // succeed.
+    const filler = "x".repeat(5 * 1024 * 1024 + 1);
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "too-big", def_yaml: filler }),
+    });
+    expect(response.status).toBe(413);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      expect(body.errors).toContain("payload_too_large");
+    }
+  });
+
+  it("returns 401 without an Authorization header (auth wired to publisher routes)", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "x", def_yaml: VALID_PIPELINE_YAML }),
+    });
+    expect(response.status).toBe(401);
+  });
+});
+
+// --- POST /pipelines/{id}/runs -----------------------------------------
+
+describe("POST /pipelines/{id}/runs", () => {
+  let server: ReturnType<typeof freshServer>;
+  beforeEach(async () => {
+    server = freshServer();
+    // Pre-register a pipeline.
+    const r = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "jobseek-add-company",
+        def_yaml: VALID_PIPELINE_YAML,
+      }),
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it("returns 404 when the pipeline id is unknown", async () => {
+    const response = await server.app.request("/pipelines/unknown/runs", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ initial_input: {} }),
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      expect(body.errors).toContain("pipeline_not_found");
+    }
+  });
+
+  it("returns 400 with failed paths when initial_input violates the pipeline schema", async () => {
+    const response = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        // Missing both required fields; `website` malformed.
+        body: JSON.stringify({ initial_input: { website: "not-a-uri" } }),
+      },
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      // At least one path should reference the missing required field.
+      const joined = body.errors.map((e) => (typeof e === "string" ? e : ""))
+        .join("\n");
+      expect(joined).toMatch(/^validation:/m);
+    }
+  });
+
+  it("returns 200 { run_id } and creates the right ready-set rows on valid input", async () => {
+    const response = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          initial_input: {
+            company_name: "ExampleCo",
+            website: "https://example.co",
+          },
+        }),
+      },
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as EnvelopeResponse<{
+      run_id: string;
+    }>;
+    expect(body.ok).toBe(true);
+    if (body.ok !== true || body.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    const runId = body.data.run_id;
+    expect(typeof runId).toBe("string");
+    expect(runId.length).toBeGreaterThan(0);
+
+    // Run row inserted with status=running.
+    const runRow = server.db
+      .prepare("SELECT status, pipeline_id FROM runs WHERE id = ?")
+      .get(runId) as { status: string; pipeline_id: string };
+    expect(runRow.status).toBe("running");
+    expect(runRow.pipeline_id).toBe("jobseek-add-company");
+
+    // Ready-set: only static subtasks with empty `requires` AND that
+    // are not the target of a `spawns.template`. In our fixture:
+    //   - pre-verify         (no requires, not a spawn template) -> READY
+    //   - setup-metadata     (requires: [pre-verify])            -> NOT in ready set
+    //   - list-boards        (requires: [pre-verify])            -> NOT in ready set
+    //   - configure-board    (no requires BUT spawn-template)    -> NOT in ready set
+    const subtaskIds = server.db
+      .prepare(
+        "SELECT subtask_id, status, claim_token FROM subtask_instances WHERE run_id = ? ORDER BY subtask_id",
+      )
+      .all(runId) as Array<{
+        subtask_id: string;
+        status: string;
+        claim_token: string | null;
+      }>;
+    expect(subtaskIds.map((r) => r.subtask_id)).toEqual(["pre-verify"]);
+    for (const r of subtaskIds) {
+      expect(r.status).toBe("ready");
+      expect(r.claim_token).toBeNull();
+    }
+  });
+});
+
+// --- GET /runs/{run_id} ------------------------------------------------
+
+describe("GET /runs/{run_id}", () => {
+  let server: ReturnType<typeof freshServer>;
+  beforeEach(async () => {
+    server = freshServer();
+    const r = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "jobseek-add-company",
+        def_yaml: VALID_PIPELINE_YAML,
+      }),
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it("returns 404 for an unknown run id", async () => {
+    const response = await server.app.request("/runs/missing-run", {
+      headers: AUTH_HEADERS,
+    });
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok === false) {
+      expect(body.errors).toContain("run_not_found");
+    }
+  });
+
+  it("returns status='running' for an in-progress run", async () => {
+    const created = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          initial_input: {
+            company_name: "ExampleCo",
+            website: "https://example.co",
+          },
+        }),
+      },
+    );
+    const createdBody = (await created.json()) as EnvelopeResponse<{
+      run_id: string;
+    }>;
+    if (createdBody.ok !== true || createdBody.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    const runId = createdBody.data.run_id;
+
+    const response = await server.app.request(`/runs/${runId}`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as EnvelopeResponse<{
+      status: string;
+      final_output?: unknown;
+      agent_actions: ReadonlyArray<unknown>;
+    }>;
+    if (body.ok !== true || body.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    expect(body.data.status).toBe("running");
+    // No subtasks have submitted; final_output is omitted.
+    expect(body.data.final_output).toBeUndefined();
+    expect(body.data.agent_actions).toEqual([]);
+  });
+
+  it("returns final_output for a completed run", async () => {
+    // Spin up a run, then mark it `completed` directly via SQL — the
+    // run-loop hasn't landed yet (M6/M7), so we exercise the GET shape
+    // by simulating the terminal state.
+    const created = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          initial_input: {
+            company_name: "ExampleCo",
+            website: "https://example.co",
+          },
+        }),
+      },
+    );
+    const createdBody = (await created.json()) as EnvelopeResponse<{
+      run_id: string;
+    }>;
+    if (createdBody.ok !== true || createdBody.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    const runId = createdBody.data.run_id;
+
+    const finalOutput = { canonical_name: "ExampleCo", boards: [] };
+    server.db
+      .prepare(
+        "UPDATE runs SET status = 'completed', final_output_json = ?, completed_at = ? WHERE id = ?",
+      )
+      .run(JSON.stringify(finalOutput), new Date().toISOString(), runId);
+
+    const response = await server.app.request(`/runs/${runId}`, {
+      headers: AUTH_HEADERS,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as EnvelopeResponse<{
+      status: string;
+      final_output?: unknown;
+      agent_actions: ReadonlyArray<unknown>;
+    }>;
+    if (body.ok !== true || body.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    expect(body.data.status).toBe("completed");
+    expect(body.data.final_output).toEqual(finalOutput);
+  });
+
+  it("truncates oversize agent_action payloads with a marker", async () => {
+    // Seed a run + instance + an action whose args/response are well above
+    // the 1 KB read-time cap.
+    const created = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          initial_input: {
+            company_name: "ExampleCo",
+            website: "https://example.co",
+          },
+        }),
+      },
+    );
+    const createdBody = (await created.json()) as EnvelopeResponse<{
+      run_id: string;
+    }>;
+    if (createdBody.ok !== true || createdBody.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    const runId = createdBody.data.run_id;
+
+    // Pull the lone ready-set instance to attach an action.
+    const instance = server.db
+      .prepare("SELECT id FROM subtask_instances WHERE run_id = ? LIMIT 1")
+      .get(runId) as { id: string };
+    const big = "z".repeat(2048);
+    server.db
+      .prepare(
+        `INSERT INTO agent_actions (instance_id, ts, kind, subcommand, args_json, response_json, truncated)
+           VALUES (?, ?, 'task_tool', 'probe monitor', ?, ?, 0)`,
+      )
+      .run(instance.id, new Date().toISOString(), big, big);
+
+    const response = await server.app.request(`/runs/${runId}`, {
+      headers: AUTH_HEADERS,
+    });
+    const body = (await response.json()) as EnvelopeResponse<{
+      agent_actions: ReadonlyArray<{
+        args_json: string | null;
+        response_json: string | null;
+        truncated: boolean;
+      }>;
+    }>;
+    if (body.ok !== true || body.data === undefined) {
+      throw new Error("expected ok=true with data");
+    }
+    expect(body.data.agent_actions.length).toBe(1);
+    const action = body.data.agent_actions[0];
+    if (action === undefined) {
+      throw new Error("expected one action");
+    }
+    expect(action.truncated).toBe(true);
+    expect(action.args_json).not.toBeNull();
+    expect(action.args_json?.length).toBeLessThan(big.length);
+    expect(action.args_json).toMatch(/truncated/);
+  });
+});

--- a/src/api/publisher/publisher.test.ts
+++ b/src/api/publisher/publisher.test.ts
@@ -266,6 +266,38 @@ final_output:
     }
   });
 
+  it("rejects non-string def_yaml with 400", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "x", def_yaml: 42 }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects YAML that parses to a non-object with 400", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      // Parses to the bare string "scalar".
+      body: JSON.stringify({ id: "x", def_yaml: "scalar" }),
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+  });
+
+  it("rejects non-JSON request body with 400", async () => {
+    const response = await server.app.request("/pipelines", {
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as EnvelopeResponse<unknown>;
+    expect(body.ok).toBe(false);
+  });
+
   it("returns 401 without an Authorization header (auth wired to publisher routes)", async () => {
     const response = await server.app.request("/pipelines", {
       method: "POST",
@@ -327,6 +359,18 @@ describe("POST /pipelines/{id}/runs", () => {
         .join("\n");
       expect(joined).toMatch(/^validation:/m);
     }
+  });
+
+  it("returns 400 when the run body is not valid JSON", async () => {
+    const response = await server.app.request(
+      "/pipelines/jobseek-add-company/runs",
+      {
+        method: "POST",
+        headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+        body: "{not json",
+      },
+    );
+    expect(response.status).toBe(400);
   });
 
   it("returns 200 { run_id } and creates the right ready-set rows on valid input", async () => {

--- a/src/api/publisher/ready_set.test.ts
+++ b/src/api/publisher/ready_set.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { PipelineDef } from "@murmur/contracts-types";
+
+import { computeReadySet, spawnTemplateIds } from "./ready_set.js";
+
+const SAMPLE: PipelineDef = {
+  id: "p",
+  initial_input: { type: "object" },
+  subtasks: [
+    {
+      id: "pre-verify",
+      instructions: "x",
+      output_schema: { type: "object" },
+    },
+    {
+      id: "setup-metadata",
+      instructions: "x",
+      requires: ["pre-verify"],
+      output_schema: { type: "object" },
+    },
+    {
+      id: "list-boards",
+      instructions: "x",
+      requires: ["pre-verify"],
+      output_schema: { type: "object" },
+      spawns: { for_each: "boards", template: "configure-board" },
+    },
+    {
+      id: "configure-board",
+      instructions: "x",
+      output_schema: { type: "object" },
+    },
+  ],
+  final_output: { composes: ["pre-verify.*"], webhook: "https://x.example" },
+};
+
+describe("spawnTemplateIds", () => {
+  it("collects every subtask id named as a spawn template", () => {
+    expect(spawnTemplateIds(SAMPLE)).toEqual(new Set(["configure-board"]));
+  });
+
+  it("returns empty set when no subtask has spawns", () => {
+    const def: PipelineDef = { ...SAMPLE, subtasks: [SAMPLE.subtasks[0]!] };
+    expect(spawnTemplateIds(def).size).toBe(0);
+  });
+});
+
+describe("computeReadySet", () => {
+  it("includes only subtasks with empty/absent requires that are not spawn templates", () => {
+    let counter = 0;
+    const rows = computeReadySet(
+      SAMPLE,
+      "r_test",
+      { hello: "world" },
+      "2026-04-29T00:00:00.000Z",
+      () => `i_${++counter}`,
+    );
+    expect(rows.map((r) => r.subtask_id)).toEqual(["pre-verify"]);
+    expect(rows[0]?.run_id).toBe("r_test");
+    expect(rows[0]?.status).toBe("ready");
+    expect(JSON.parse(rows[0]?.input_json ?? "")).toEqual({ hello: "world" });
+    expect(rows[0]?.created_at).toBe("2026-04-29T00:00:00.000Z");
+    expect(rows[0]?.id).toBe("i_1");
+  });
+
+  it("treats requires:[] (empty array) the same as absent requires", () => {
+    const def: PipelineDef = {
+      ...SAMPLE,
+      subtasks: [
+        {
+          id: "a",
+          instructions: "x",
+          requires: [],
+          output_schema: { type: "object" },
+        },
+      ],
+      final_output: { composes: ["a.*"], webhook: "https://x.example" },
+    };
+    const rows = computeReadySet(
+      def,
+      "r",
+      {},
+      "2026-04-29T00:00:00.000Z",
+      () => "i_a",
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.subtask_id).toBe("a");
+  });
+});

--- a/src/api/publisher/ready_set.ts
+++ b/src/api/publisher/ready_set.ts
@@ -57,7 +57,14 @@ export interface ReadyRow {
  * @returns the set of spawn-template subtask ids (lookup-friendly).
  */
 export function spawnTemplateIds(def: PipelineDef): ReadonlySet<string> {
-  throw new Error("not implemented");
+  const ids = new Set<string>();
+  for (const subtask of def.subtasks) {
+    const spawns = subtask.spawns;
+    if (spawns !== undefined) {
+      ids.add(spawns.template);
+    }
+  }
+  return ids;
 }
 
 /**
@@ -74,8 +81,8 @@ export function spawnTemplateIds(def: PipelineDef): ReadonlySet<string> {
  * `initial_input` is the conservative choice and matches what the
  * agent will see in `pull_task` until M6 wires per-subtask resolution.
  *
- * The function does NOT mint instance ids or touch the DB; it returns
- * data the caller will insert inside its run-creation transaction.
+ * The function does NOT touch the DB; it returns data the caller will
+ * insert inside its run-creation transaction.
  *
  * @param def the validated pipeline definition.
  * @param runId the freshly-minted run id.
@@ -94,5 +101,22 @@ export function computeReadySet(
   now: string,
   mintInstanceId: () => string,
 ): ReadonlyArray<ReadyRow> {
-  throw new Error("not implemented");
+  const templates = spawnTemplateIds(def);
+  const inputJson = JSON.stringify(initialInput);
+  const rows: ReadyRow[] = [];
+  for (const subtask of def.subtasks) {
+    if (templates.has(subtask.id)) continue;
+    const requires = subtask.requires ?? [];
+    if (requires.length > 0) continue;
+    rows.push({
+      id: mintInstanceId(),
+      run_id: runId,
+      subtask_id: subtask.id,
+      status: "ready",
+      input_json: inputJson,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+  return rows;
 }

--- a/src/api/publisher/ready_set.ts
+++ b/src/api/publisher/ready_set.ts
@@ -1,0 +1,98 @@
+/**
+ * Ready-set computation for `POST /pipelines/{id}/runs`.
+ *
+ * The "ready set" is the set of subtask_instances that are eligible to
+ * be claimed at run start — i.e., before any subtask has submitted.
+ * For the MVP these are exactly the static subtasks that:
+ *
+ *   1. Have an empty or absent `requires` array (no upstream
+ *      dependencies — DESIGN.md §3.1, last bullet on schema fields).
+ *   2. Are NOT the template of some other subtask's `spawns` block.
+ *      Spawn-template subtasks are instantiated dynamically when their
+ *      parent submits; they have no row at run-start.
+ *
+ * The function is pure — given the validated pipeline def, the run id,
+ * and the resolved initial input, it returns the rows to insert. The
+ * DB write is the caller's responsibility (kept transactional with the
+ * `runs` insert).
+ *
+ * @see DESIGN.md §3.1 — `requires`, `spawns`
+ * @see src/db/schema.md — `subtask_instances` columns
+ */
+
+import type { PipelineDef } from "@murmur/contracts-types";
+
+/**
+ * One row to insert into `subtask_instances` at run start.
+ *
+ * Mirrors the column set of `subtask_instances` (see `src/db/schema.md`).
+ * `claim_token`, `expires_at`, `parent_instance_id`, `spawn_index` are
+ * intentionally omitted — they default to NULL for ready-set rows
+ * (the rows aren't claimed and aren't spawned children).
+ */
+export interface ReadyRow {
+  /** Caller-minted instance id (`i_<hex>`). */
+  readonly id: string;
+  /** Run id this row belongs to. */
+  readonly run_id: string;
+  /** Pipeline-def subtask id (e.g., `pre-verify`). */
+  readonly subtask_id: string;
+  /** Always `"ready"` for ready-set rows. */
+  readonly status: "ready";
+  /** JSON-encoded resolved input for this instance. */
+  readonly input_json: string;
+  /** RFC 3339 timestamp; `created_at` and `updated_at` are equal at insert. */
+  readonly created_at: string;
+  /** RFC 3339 timestamp. */
+  readonly updated_at: string;
+}
+
+/**
+ * Identify subtask ids that are spawn templates — i.e., that appear as
+ * the `template` of some other subtask's `spawns` block. These are NOT
+ * in the ready set because their instances are created dynamically when
+ * the parent submits.
+ *
+ * @param def a validated pipeline definition.
+ * @returns the set of spawn-template subtask ids (lookup-friendly).
+ */
+export function spawnTemplateIds(def: PipelineDef): ReadonlySet<string> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Compute the initial ready-set rows for a new run.
+ *
+ * Selection rules (per the module docblock):
+ *   - subtask is NOT a spawn template, AND
+ *   - `requires` is absent or empty.
+ *
+ * Each ready row's `input_json` is the JSON-encoded `initial_input` for
+ * the run — the MVP does not (yet) resolve per-subtask `inputs` from
+ * named refs into the publisher's initial input. For ready-set rows
+ * authored from the static subtask list, passing the run-level
+ * `initial_input` is the conservative choice and matches what the
+ * agent will see in `pull_task` until M6 wires per-subtask resolution.
+ *
+ * The function does NOT mint instance ids or touch the DB; it returns
+ * data the caller will insert inside its run-creation transaction.
+ *
+ * @param def the validated pipeline definition.
+ * @param runId the freshly-minted run id.
+ * @param initialInput the publisher-supplied `initial_input` value.
+ * @param now an RFC 3339 timestamp string used for `created_at` /
+ *   `updated_at`. Passed in (rather than read from `Date.now()`) so the
+ *   function is deterministic under test.
+ * @param mintInstanceId function called once per ready row to obtain a
+ *   unique `i_<hex>` id. Injectable so tests can stub.
+ * @returns the rows to insert, in subtask-def declaration order.
+ */
+export function computeReadySet(
+  def: PipelineDef,
+  runId: string,
+  initialInput: unknown,
+  now: string,
+  mintInstanceId: () => string,
+): ReadonlyArray<ReadyRow> {
+  throw new Error("not implemented");
+}

--- a/src/api/publisher/runs.ts
+++ b/src/api/publisher/runs.ts
@@ -1,0 +1,62 @@
+/**
+ * `GET /runs/{run_id}` route handler.
+ *
+ * Returns the publisher-facing run status: the run's current status,
+ * its final output (when completed), and the per-subtask audit trail.
+ * Each `agent_actions` row's `args_json`/`response_json` payloads are
+ * truncated per `./truncate.ts` so the response stays scannable for a
+ * long-running pipeline.
+ *
+ * @see DESIGN.md §3.2 — GET /runs/{run_id}
+ */
+
+import type Database from "better-sqlite3";
+import type { Hono } from "hono";
+
+/**
+ * One audit-log entry returned in `GET /runs/{run_id}`.
+ *
+ * Payload fields are clipped to {@link AGENT_ACTION_PAYLOAD_CAP_BYTES}
+ * with a {@link TRUNCATION_MARKER} suffix when oversize.
+ */
+export interface AgentActionView {
+  readonly id: number;
+  readonly instance_id: string;
+  readonly subtask_id: string;
+  readonly ts: string;
+  readonly kind: string;
+  readonly subcommand: string | null;
+  readonly args_json: string | null;
+  readonly response_json: string | null;
+  readonly truncated: boolean;
+}
+
+/**
+ * Body shape returned by `GET /runs/{run_id}` on success.
+ *
+ * `final_output` is present iff `status === 'completed'`; `agent_actions`
+ * is always present (empty array when the run has no actions yet).
+ */
+export interface RunStatusView {
+  readonly run_id: string;
+  readonly pipeline_id: string;
+  readonly pipeline_version: number;
+  readonly status: string;
+  readonly final_output?: unknown;
+  readonly agent_actions: ReadonlyArray<AgentActionView>;
+}
+
+/**
+ * Mount the `GET /runs/{run_id}` route onto the given Hono sub-app.
+ *
+ * Routes:
+ *   - `GET /runs/{run_id}`
+ *     • 200 `{ ok: true, data: RunStatusView }` on success.
+ *     • 404 `{ ok: false, errors: ["run_not_found"] }` if unknown.
+ *
+ * @param app the sub-app to mount onto.
+ * @param db the open SQLite handle.
+ */
+export function mountRunRoutes(app: Hono, db: Database.Database): void {
+  throw new Error("not implemented");
+}

--- a/src/api/publisher/runs.ts
+++ b/src/api/publisher/runs.ts
@@ -13,6 +13,13 @@
 import type Database from "better-sqlite3";
 import type { Hono } from "hono";
 
+import type { Err, Ok } from "@murmur/contracts-types";
+
+import {
+  AGENT_ACTION_PAYLOAD_CAP_BYTES,
+  truncatePayload,
+} from "./truncate.js";
+
 /**
  * One audit-log entry returned in `GET /runs/{run_id}`.
  *
@@ -46,6 +53,28 @@ export interface RunStatusView {
   readonly agent_actions: ReadonlyArray<AgentActionView>;
 }
 
+/** Shape of the `runs` row we read. */
+interface RunRow {
+  readonly id: string;
+  readonly pipeline_id: string;
+  readonly pipeline_version: number;
+  readonly status: string;
+  readonly final_output_json: string | null;
+}
+
+/** Shape of the joined `agent_actions` row we read. */
+interface AgentActionRow {
+  readonly id: number;
+  readonly instance_id: string;
+  readonly subtask_id: string;
+  readonly ts: string;
+  readonly kind: string;
+  readonly subcommand: string | null;
+  readonly args_json: string | null;
+  readonly response_json: string | null;
+  readonly truncated: number;
+}
+
 /**
  * Mount the `GET /runs/{run_id}` route onto the given Hono sub-app.
  *
@@ -58,5 +87,75 @@ export interface RunStatusView {
  * @param db the open SQLite handle.
  */
 export function mountRunRoutes(app: Hono, db: Database.Database): void {
-  throw new Error("not implemented");
+  const selectRun = db.prepare(
+    `SELECT id, pipeline_id, pipeline_version, status, final_output_json
+       FROM runs WHERE id = ?`,
+  );
+  // Join through subtask_instances so the audit row carries `subtask_id`
+  // — agent_actions itself only knows `instance_id`.
+  const selectActions = db.prepare(
+    `SELECT a.id, a.instance_id, i.subtask_id, a.ts, a.kind, a.subcommand,
+            a.args_json, a.response_json, a.truncated
+       FROM agent_actions a
+       JOIN subtask_instances i ON i.id = a.instance_id
+      WHERE i.run_id = ?
+      ORDER BY a.id ASC`,
+  );
+
+  app.get("/runs/:run_id", (c) => {
+    const runId = c.req.param("run_id");
+    if (runId === undefined || runId === "") {
+      const err: Err = { ok: false, errors: ["run_id_required"] };
+      return c.json(err, 400);
+    }
+    const row = selectRun.get(runId) as RunRow | undefined;
+    if (row === undefined) {
+      const err: Err = { ok: false, errors: ["run_not_found"] };
+      return c.json(err, 404);
+    }
+
+    const actionRows = selectActions.all(runId) as ReadonlyArray<AgentActionRow>;
+    const agent_actions: AgentActionView[] = [];
+    for (const a of actionRows) {
+      const args = truncatePayload(a.args_json, AGENT_ACTION_PAYLOAD_CAP_BYTES);
+      const resp = truncatePayload(
+        a.response_json,
+        AGENT_ACTION_PAYLOAD_CAP_BYTES,
+      );
+      agent_actions.push({
+        id: a.id,
+        instance_id: a.instance_id,
+        subtask_id: a.subtask_id,
+        ts: a.ts,
+        kind: a.kind,
+        subcommand: a.subcommand,
+        args_json: args.text,
+        response_json: resp.text,
+        // The DB-side `truncated` flag is set when M5+ writes oversize
+        // payloads (capped at 4 KB); we OR it with our read-time flag so
+        // either kind of truncation surfaces to the caller.
+        truncated:
+          a.truncated > 0 || args.truncated || resp.truncated,
+      });
+    }
+
+    const view: RunStatusView = row.final_output_json !== null
+      ? {
+          run_id: row.id,
+          pipeline_id: row.pipeline_id,
+          pipeline_version: row.pipeline_version,
+          status: row.status,
+          final_output: JSON.parse(row.final_output_json) as unknown,
+          agent_actions,
+        }
+      : {
+          run_id: row.id,
+          pipeline_id: row.pipeline_id,
+          pipeline_version: row.pipeline_version,
+          status: row.status,
+          agent_actions,
+        };
+    const ok: Ok<RunStatusView> = { ok: true, data: view };
+    return c.json(ok, 200);
+  });
 }

--- a/src/api/publisher/schema.test.ts
+++ b/src/api/publisher/schema.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { PIPELINE_DEF_SCHEMA, loadPipelineDefSchema } from "./schema.js";
+
+describe("loadPipelineDefSchema", () => {
+  it("returns a JSON Schema object with the expected $id", () => {
+    const schema = loadPipelineDefSchema() as { $id?: string; type?: string };
+    expect(schema.type).toBe("object");
+    expect(schema.$id).toMatch(/pipeline-def\.schema\.json$/);
+  });
+
+  it("PIPELINE_DEF_SCHEMA module-level export is the same shape", () => {
+    const top = PIPELINE_DEF_SCHEMA as { type?: string };
+    expect(top.type).toBe("object");
+  });
+});

--- a/src/api/publisher/schema.ts
+++ b/src/api/publisher/schema.ts
@@ -14,17 +14,19 @@
  * @see DESIGN.md §3.2 — POST /pipelines
  */
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
 /**
- * The parsed pipeline-def JSON Schema document. Stable reference; the
- * runtime cache in `src/dispatch/validation.ts` is keyed by reference,
- * so re-loading on every request would defeat the cache.
- *
- * Type is `object` because the schema has many nested fields the
- * publisher API does not depend on directly — Ajv consumes it as a
- * generic JSON Schema document.
+ * Resolve `docs/contracts/pipeline-def.schema.json` relative to the
+ * package root. This file lives at `src/api/publisher/schema.ts`, so
+ * three `..` segments climb out to the package root.
  */
-export const PIPELINE_DEF_SCHEMA: Readonly<Record<string, unknown>> =
-  loadPipelineDefSchema();
+function schemaPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, "..", "..", "..", "docs", "contracts", "pipeline-def.schema.json");
+}
 
 /**
  * Internal loader — exported only for testing. Reads
@@ -33,5 +35,20 @@ export const PIPELINE_DEF_SCHEMA: Readonly<Record<string, unknown>> =
  * deployment misconfiguration).
  */
 export function loadPipelineDefSchema(): Readonly<Record<string, unknown>> {
-  throw new Error("not implemented");
+  const raw = readFileSync(schemaPath(), "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `loadPipelineDefSchema: ${schemaPath()} did not parse to a JSON object`,
+    );
+  }
+  return parsed as Readonly<Record<string, unknown>>;
 }
+
+/**
+ * The parsed pipeline-def JSON Schema document. Stable reference; the
+ * runtime cache in `src/dispatch/validation.ts` is keyed by reference,
+ * so re-loading on every request would defeat the cache.
+ */
+export const PIPELINE_DEF_SCHEMA: Readonly<Record<string, unknown>> =
+  loadPipelineDefSchema();

--- a/src/api/publisher/schema.ts
+++ b/src/api/publisher/schema.ts
@@ -1,0 +1,37 @@
+/**
+ * Pipeline-def JSON Schema loader.
+ *
+ * `POST /pipelines` validates incoming pipeline definitions against
+ * `docs/contracts/pipeline-def.schema.json` (the M0 boundary contract).
+ * The schema is loaded once at module import and reused across requests.
+ *
+ * Loading happens via `fs.readFileSync` rather than `import ... assert`
+ * so the path is robust to the bundler/runtime mode (`tsx`, native ESM,
+ * tests run from various CWDs). The path is resolved relative to this
+ * source file, not the process CWD.
+ *
+ * @see docs/contracts/pipeline-def.schema.json
+ * @see DESIGN.md §3.2 — POST /pipelines
+ */
+
+/**
+ * The parsed pipeline-def JSON Schema document. Stable reference; the
+ * runtime cache in `src/dispatch/validation.ts` is keyed by reference,
+ * so re-loading on every request would defeat the cache.
+ *
+ * Type is `object` because the schema has many nested fields the
+ * publisher API does not depend on directly — Ajv consumes it as a
+ * generic JSON Schema document.
+ */
+export const PIPELINE_DEF_SCHEMA: Readonly<Record<string, unknown>> =
+  loadPipelineDefSchema();
+
+/**
+ * Internal loader — exported only for testing. Reads
+ * `docs/contracts/pipeline-def.schema.json` from disk. Throws if the
+ * file is missing or malformed (boot fails fast — these would be a
+ * deployment misconfiguration).
+ */
+export function loadPipelineDefSchema(): Readonly<Record<string, unknown>> {
+  throw new Error("not implemented");
+}

--- a/src/api/publisher/truncate.test.ts
+++ b/src/api/publisher/truncate.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_ACTION_PAYLOAD_CAP_BYTES,
+  TRUNCATION_MARKER,
+  truncatePayload,
+} from "./truncate.js";
+
+describe("truncatePayload", () => {
+  it("returns null and truncated=false for null input", () => {
+    expect(truncatePayload(null, AGENT_ACTION_PAYLOAD_CAP_BYTES)).toEqual({
+      text: null,
+      truncated: false,
+    });
+  });
+
+  it("passes short strings through unchanged", () => {
+    const short = "hello";
+    expect(truncatePayload(short, AGENT_ACTION_PAYLOAD_CAP_BYTES)).toEqual({
+      text: short,
+      truncated: false,
+    });
+  });
+
+  it("clips long strings and appends the marker", () => {
+    const big = "a".repeat(AGENT_ACTION_PAYLOAD_CAP_BYTES + 100);
+    const result = truncatePayload(big, AGENT_ACTION_PAYLOAD_CAP_BYTES);
+    expect(result.truncated).toBe(true);
+    expect(result.text).not.toBeNull();
+    expect(result.text?.endsWith(TRUNCATION_MARKER)).toBe(true);
+  });
+
+  it("never splits a multi-byte UTF-8 sequence", () => {
+    // 4-byte emoji repeated. The cap may fall mid-sequence; the helper
+    // must back off to a code-point boundary.
+    const emoji = "\u{1F600}"; // 4 bytes in UTF-8
+    const big = emoji.repeat(500); // ~2000 bytes
+    const result = truncatePayload(big, 1024);
+    expect(result.truncated).toBe(true);
+    // Decoding the result must succeed (no broken code units).
+    expect(() => Buffer.from(result.text ?? "", "utf8").toString("utf8"))
+      .not.toThrow();
+  });
+
+  it("at exactly capBytes is not truncated", () => {
+    const exact = "x".repeat(AGENT_ACTION_PAYLOAD_CAP_BYTES);
+    expect(truncatePayload(exact, AGENT_ACTION_PAYLOAD_CAP_BYTES)).toEqual({
+      text: exact,
+      truncated: false,
+    });
+  });
+});

--- a/src/api/publisher/truncate.ts
+++ b/src/api/publisher/truncate.ts
@@ -62,5 +62,28 @@ export function truncatePayload(
   json: string | null,
   capBytes: number,
 ): TruncatedPayload {
-  throw new Error("not implemented");
+  if (json === null) {
+    return { text: null, truncated: false };
+  }
+
+  // Fast path: most rows are within cap. Use Buffer.byteLength to count
+  // UTF-8 bytes without allocating an intermediate buffer.
+  const byteLen = Buffer.byteLength(json, "utf8");
+  if (byteLen <= capBytes) {
+    return { text: json, truncated: false };
+  }
+
+  // Slow path: clip to exactly `capBytes` bytes, never splitting a
+  // multi-byte UTF-8 sequence. We construct a Buffer view and decode
+  // with `TextDecoder({ fatal: false })`; the decoder will replace a
+  // dangling continuation byte with U+FFFD, but we want to drop trailing
+  // partial sequences entirely. Easiest way: decode permissively, then
+  // strip any trailing replacement char.
+  const buf = Buffer.from(json, "utf8");
+  const slice = buf.subarray(0, capBytes);
+  // `TextDecoder` with `fatal: false` is the default; trailing partials
+  // become U+FFFD. Trim them off.
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(slice);
+  const cleaned = decoded.replace(/�+$/u, "");
+  return { text: `${cleaned}${TRUNCATION_MARKER}`, truncated: true };
 }

--- a/src/api/publisher/truncate.ts
+++ b/src/api/publisher/truncate.ts
@@ -1,0 +1,66 @@
+/**
+ * Payload truncation helper for `GET /runs/{run_id}`.
+ *
+ * Each `agent_actions` row carries `args_json` and `response_json` columns.
+ * For the publisher-facing audit trail we cap each field at
+ * {@link AGENT_ACTION_PAYLOAD_CAP_BYTES} bytes; oversize values are
+ * clipped and a `…(truncated)` marker is appended so the consumer can
+ * distinguish a clipped value from a value that happens to end at the
+ * cap. The cap is per-field, not per-row, matching DESIGN.md §3.6's
+ * audit-log payload truncation guidance.
+ *
+ * The unit is BYTES (UTF-8 length), not code points — JSON consumers
+ * compare lengths in bytes, and a code-point cap would let four-byte
+ * graphemes blow past the intended limit.
+ *
+ * @see DESIGN.md §3.6 — Audit log payload truncation
+ */
+
+/**
+ * Per-payload byte cap used when serializing `agent_actions[*].args_json`
+ * and `agent_actions[*].response_json` in `GET /runs/{run_id}`. The DB
+ * already truncates writes to 4 KB (per §3.6); the read-time cap is
+ * smaller (1 KB) so large audit trails stay scannable in a poll.
+ */
+export const AGENT_ACTION_PAYLOAD_CAP_BYTES = 1024;
+
+/**
+ * Marker appended to a truncated payload so callers can detect clipping.
+ * Stable wire-format token — do not change without coordinating with
+ * publisher-side log viewers.
+ */
+export const TRUNCATION_MARKER = "…(truncated)";
+
+/**
+ * Result of {@link truncatePayload}.
+ *
+ * - `text`: the (possibly clipped) string, or `null` if the input was `null`.
+ * - `truncated`: `true` if and only if the input exceeded `capBytes`.
+ */
+export interface TruncatedPayload {
+  readonly text: string | null;
+  readonly truncated: boolean;
+}
+
+/**
+ * Truncate a JSON-bearing string field to `capBytes` UTF-8 bytes,
+ * appending {@link TRUNCATION_MARKER} when clipping occurred.
+ *
+ * Behaviour:
+ *   - `null` input → `{ text: null, truncated: false }`. The DB column
+ *     allows NULL for `args_json`/`response_json`; preserve it.
+ *   - input within cap → returned unchanged, `truncated: false`.
+ *   - input above cap → clipped to `capBytes` bytes (UTF-8 safe — never
+ *     splits a multi-byte sequence) and the marker is appended.
+ *     `truncated: true`.
+ *
+ * @param json the payload string from the DB (or `null`).
+ * @param capBytes the maximum size in bytes; must be ≥ marker length.
+ * @returns the (possibly clipped) text and a flag.
+ */
+export function truncatePayload(
+  json: string | null,
+  capBytes: number,
+): TruncatedPayload {
+  throw new Error("not implemented");
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,10 @@
+import type Database from "better-sqlite3";
 import { Hono } from "hono";
 
 import type { Err } from "@murmur/contracts-types";
 
 import { bearerAuth } from "./auth/index.js";
+import { createPublisherApp } from "./api/publisher/index.js";
 
 /**
  * Options accepted by `createServer`.
@@ -21,6 +23,19 @@ export interface CreateServerOptions {
    * before calling `createServer`.
    */
   token: Buffer;
+  /**
+   * Open SQLite handle. When supplied, the publisher sub-app
+   * (`src/api/publisher`) is mounted and serves `POST /pipelines`,
+   * `POST /pipelines/{id}/runs`, and `GET /runs/{run_id}`. When omitted,
+   * the publisher routes are absent and any request to those paths falls
+   * through to the 404 handler (e.g. tests that only exercise auth).
+   *
+   * The factory does NOT take ownership — callers are responsible for
+   * lifecycle. Migrations MUST have been run on the handle before
+   * `createServer` is called; the publisher sub-app assumes the schema
+   * is already in place.
+   */
+  db?: Database.Database;
 }
 
 /**
@@ -50,6 +65,16 @@ export function createServer(options: CreateServerOptions): Hono {
   app.use("*", bearerAuth(options.token));
 
   app.get("/health", (c) => c.json({ ok: true }));
+
+  // Publisher sub-app: registered only when a DB handle was supplied.
+  // The sub-app exposes `POST /pipelines`, `POST /pipelines/{id}/runs`,
+  // and `GET /runs/{run_id}`. Mounted at `/` because each route owns
+  // its own absolute path; bearer-auth above the mount applies. See
+  // `src/api/publisher/index.ts`.
+  if (options.db !== undefined) {
+    const publisher = createPublisherApp({ db: options.db });
+    app.route("/", publisher);
+  }
 
   // 404 fallback. The body conforms to M0's `Err` envelope shape:
   // `{ ok: false, errors: ["not_found"] }`. The string-token form is the


### PR DESCRIPTION
## Summary
Adds the three publisher-facing endpoints from DESIGN.md §3.2 (issue #9):

- `POST /pipelines` — register/upsert pipeline def. 5 MB body cap, YAML parse, validation against `docs/contracts/pipeline-def.schema.json` plus a deeper walk that compiles every inner JSON Schema (`initial_input`, every `output_schema`, every subcommand `input_schema`). Last-write-wins UPSERT bumps `version`.
- `POST /pipelines/{id}/runs` — start a run. 404 on unknown pipeline, validate `initial_input` against the pipeline's `initial_input` schema, then transactionally insert the `runs` row + ready-set `subtask_instances` rows (status='ready', claim_token=NULL).
- `GET /runs/{run_id}` — poll status. 404 on unknown. Returns `{ status, final_output?, agent_actions[] }`; each `agent_actions` row has its `args_json`/`response_json` clipped to 1 KB with a `…(truncated)` suffix and a `truncated` flag.

Implementation lives entirely in a new `src/api/publisher/` sub-app; `src/server.ts` mounts it when a `db` handle is supplied to `createServer`. The publisher routes inherit the existing M3 bearer-auth middleware unchanged.

## Related issue
Closes colophon-group/murmur#9

## Files changed (high-level)
- `src/api/publisher/index.ts` — sub-app factory `createPublisherApp({ db })`
- `src/api/publisher/pipelines.ts` — POST /pipelines + POST /pipelines/{id}/runs handlers; YAML parse; outer + inner JSON Schema validation; UPSERT; transactional run-creation
- `src/api/publisher/runs.ts` — GET /runs/{run_id}; joined agent_actions; per-row truncation
- `src/api/publisher/ready_set.ts` — pure `computeReadySet` (subtasks with empty/absent `requires` AND not a spawn template)
- `src/api/publisher/truncate.ts` — UTF-8-safe per-payload truncation + marker
- `src/api/publisher/schema.ts` — boots-once load of `docs/contracts/pipeline-def.schema.json`
- `src/api/publisher/ids.ts` — `r_<hex>` / `i_<hex>` opaque ids via `crypto.randomBytes`
- `src/api/publisher/*.test.ts` — 33 tests across the sub-app
- `src/server.ts` — extended `CreateServerOptions` with optional `db?: Database`; mounts publisher sub-app when provided
- `package.json` — added `yaml` dep

## Verification (from the issue)
- [x] POST /pipelines with valid YAML → 200 { id }
- [x] POST /pipelines with malformed YAML → 400 with parse error
- [x] POST /pipelines with invalid JSON Schema → 400 with schema-error path (both outer-shape and inner-schema-typo cases)
- [x] POST /pipelines twice with same id → second wins; version bumps to 2
- [x] POST /pipelines/unknown/runs → 404
- [x] POST /pipelines/{id}/runs with bad initial_input → 400 listing failed paths
- [x] POST /pipelines/{id}/runs with valid input → 200 { run_id }; ready-set rows in DB with status='ready', claim_token=NULL
- [x] GET /runs/unknown → 404
- [x] GET /runs/{run_id} for in-progress run → status='running'
- [x] GET /runs/{run_id} for completed run → final_output populated
- [x] POST /pipelines body > 5 MB → 413 payload_too_large
- [x] Bearer missing on POST /pipelines → 401 (auth-wiring smoke)
- [x] After POST /runs the subtask_instances table contains only the rows whose `requires` are empty/satisfied AND that are not spawn-template targets (i.e. exactly `pre-verify` for the four-subtask fixture)

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓ (zero warnings)
- `pnpm test` ✓ — 118 root tests + 34 contracts-types tests, all green; coverage on `src/api/publisher/**`: 88.47% lines, 80% branches (gate is 85/75)
- `pnpm grep:all` ✓ — every gate green; no `accepted:` shape introduced
- `pnpm build` ✓

## Notes for reviewer
- The pipeline-def schema only asserts each schema slot is a JSON object; we do the deeper "is this a compilable JSON Schema" walk in `validateInnerSchemas` so a typo like `requried:` is caught at registration. Inner-schema errors are formatted `validation:<json-pointer>:<msg>` with the JSON Pointer rooted at the pipeline def (e.g. `/subtasks/0/output_schema:...`).
- Ready-set semantics: a subtask is in the initial ready set iff `requires` is empty/absent AND it is not the `template` of any other subtask's `spawns` block. The §3.1 example fixture has `requires` declared, so only `pre-verify` qualifies — that's what the test asserts. M6/M7 will fan out the rest.
- The 5 MB body cap reads `arrayBuffer()` once and rejects on length BEFORE attempting to JSON-decode, so a 6 MB body never reaches the YAML parser.
- `src/server.ts` change is a single conditional mount; the existing M3 bearer-auth middleware is unchanged and still gates every publisher route.
- `GET /runs/{run_id}` joins `subtask_instances` to surface `subtask_id` per audit row; the per-row `truncated` flag is the OR of the DB-side flag (set by M5+ writers) and our read-time clip flag.