### PR TITLE
feat(api): agent atomic claim + CAS submit endpoints

### DIFF
--- a/src/api/agent/agent.test.ts
+++ b/src/api/agent/agent.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import type Database from "better-sqlite3";
 
@@ -270,7 +270,59 @@ describe("Concurrency stress: atomic claim has no duplicates", () => {
 
       // Seed 10 ready subtasks, all on the same run for simplicity.
       const ids = Array.from({ length: 10 }, (_, i) => `t${i}`);
-      seedRun(h.db, "run-S", ids, h.nowFn(), { readyIds: ids });
+
+      // The default test pipeline only declares `first` and `second`;
+      // for this test we install a parallel pipeline that declares
+      // every t0..t9. The agent app reads pipelines by joining via
+      // run_id, so we register a fresh pipeline + run.
+      const stressPipelineId = "stress-pipeline";
+      const stressDef = {
+        id: stressPipelineId,
+        subtasks: ids.map((id) => ({
+          id,
+          instructions: `do ${id}`,
+          output_schema: {
+            type: "object",
+            properties: { ok: { type: "boolean" } },
+            required: ["ok"],
+            additionalProperties: false,
+          },
+        })),
+      };
+      h.db
+        .prepare(
+          `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+           VALUES (?, 1, ?, ?, ?)`,
+        )
+        .run(
+          stressPipelineId,
+          JSON.stringify(stressDef),
+          h.nowFn(),
+          h.nowFn(),
+        );
+      h.db
+        .prepare(
+          `INSERT INTO runs
+             (id, pipeline_id, pipeline_version, status, initial_input_json,
+              webhook_url, created_at)
+           VALUES (?, ?, 1, 'running', '{}', 'https://example.test/webhook', ?)`,
+        )
+        .run("run-S", stressPipelineId, h.nowFn());
+
+      let i = 0;
+      for (const subtaskId of ids) {
+        const created = new Date(
+          new Date(h.nowFn()).getTime() + i,
+        ).toISOString();
+        h.db
+          .prepare(
+            `INSERT INTO subtask_instances
+               (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+             VALUES (?, ?, ?, 'ready', '{}', ?, ?)`,
+          )
+          .run(`run-S-${subtaskId}`, "run-S", subtaskId, created, created);
+        i += 1;
+      }
 
       const calls: Promise<{
         status: number;
@@ -522,6 +574,187 @@ describe("POST /work/{claim_token}/result", () => {
       expect(actions.some((a) => a.kind === "claim")).toBe(true);
     } finally {
       h.db.close();
+    }
+  });
+});
+
+/* ---------- Error envelope edge cases ---------- */
+
+describe("POST /work/{claim_token}/result — input-shape edges", () => {
+  it("with malformed JSON body → { ok: false, errors: ['bad_json'] }", async () => {
+    const h = makeHarness();
+    try {
+      const response = await h.app.request("/c_anything/result", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{not json",
+      });
+      const parsed = (await response.json()) as EnvelopeResponse<unknown>;
+      expect(response.status).toBe(400);
+      expect(parsed).toEqual({ ok: false, errors: ["bad_json"] });
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("with body missing `result` key → { ok: false, errors: ['bad_request'] }", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      const response = await h.app.request(`/${token}/result`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "no result key" }),
+      });
+      const parsed = (await response.json()) as EnvelopeResponse<unknown>;
+      expect(response.status).toBe(400);
+      expect(parsed).toEqual({ ok: false, errors: ["bad_request"] });
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+describe("/work/next pipeline-def drift", () => {
+  it("returns 500 pipeline_not_found if the run's pipeline def is missing the subtask", async () => {
+    const h = makeHarness();
+    try {
+      // Insert a run pointing at a pipeline whose def lacks the subtask we
+      // queue. This simulates schema drift between run-start and now.
+      const driftDef = { id: "drift", subtasks: [] };
+      h.db
+        .prepare(
+          `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+           VALUES (?, 1, ?, ?, ?)`,
+        )
+        .run("drift", JSON.stringify(driftDef), h.nowFn(), h.nowFn());
+      h.db
+        .prepare(
+          `INSERT INTO runs
+             (id, pipeline_id, pipeline_version, status, initial_input_json,
+              webhook_url, created_at)
+           VALUES ('run-D', 'drift', 1, 'running', '{}',
+                   'https://example.test/webhook', ?)`,
+        )
+        .run(h.nowFn());
+      h.db
+        .prepare(
+          `INSERT INTO subtask_instances
+             (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+           VALUES ('run-D-x', 'run-D', 'unknown-subtask', 'ready', '{}', ?, ?)`,
+        )
+        .run(h.nowFn(), h.nowFn());
+
+      const response = await h.app.request("/next", { method: "GET" });
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as EnvelopeResponse<unknown>;
+      expect(body).toEqual({ ok: false, errors: ["pipeline_not_found"] });
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+/* ---------- Audit truncation ---------- */
+
+describe("audit log truncation (DESIGN.md §3.6, 4 KB cap)", () => {
+  it("agent_actions row is marked truncated=1 when args_json > 4 KB", async () => {
+    // Use a permissive output schema that accepts large payloads.
+    const db = openDb(":memory:");
+    runMigrations(db);
+    const def = {
+      id: "big-pipeline",
+      subtasks: [
+        {
+          id: "first",
+          instructions: "go",
+          // No `additionalProperties: false` so a huge `pad` field is accepted.
+          output_schema: { type: "object" },
+        },
+      ],
+    };
+    const now = "2026-04-29T12:00:00.000Z";
+    db.prepare(
+      `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+       VALUES (?, 1, ?, ?, ?)`,
+    ).run("big-pipeline", JSON.stringify(def), now, now);
+    db.prepare(
+      `INSERT INTO runs
+         (id, pipeline_id, pipeline_version, status, initial_input_json,
+          webhook_url, created_at)
+       VALUES ('run-B', 'big-pipeline', 1, 'running', '{}',
+               'https://example.test/webhook', ?)`,
+    ).run(now);
+    db.prepare(
+      `INSERT INTO subtask_instances
+         (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+       VALUES ('run-B-first', 'run-B', 'first', 'ready', '{}', ?, ?)`,
+    ).run(now, now);
+
+    const app = createAgentApp({ db, nowFn: () => now });
+    try {
+      const claim = await getJson<NextWorkData>(app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      // Build a result whose JSON encoding exceeds the 4 KB cap.
+      const padding = "x".repeat(8 * 1024);
+      const submit = await postJson<SubmitOkData>(
+        app,
+        `/${token}/result`,
+        { result: { pad: padding } },
+      );
+      expect(submit.body.ok).toBe(true);
+
+      const action = db
+        .prepare(
+          `SELECT truncated FROM agent_actions
+             WHERE instance_id = 'run-B-first' AND kind = 'submit_result'`,
+        )
+        .get() as { truncated: number } | undefined;
+      expect(action?.truncated).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+/* ---------- Default seams (no clock/RNG override) ---------- */
+
+describe("default seams", () => {
+  it("createAgentApp without nowFn/claimTokenFn uses real defaults and still issues claims", async () => {
+    // Exercises the default-fallback branches for `nowFn` and
+    // `claimTokenFn` (i.e. `freshClaimToken` + `nowIso`).
+    const db = openDb(":memory:");
+    runMigrations(db);
+    db.prepare(
+      `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      TEST_PIPELINE_ID,
+      TEST_PIPELINE_VERSION,
+      JSON.stringify(TEST_PIPELINE_DEF),
+      new Date().toISOString(),
+      new Date().toISOString(),
+    );
+    const app = createAgentApp({ db });
+    seedRun(db, "run-default", ["first", "second"], new Date().toISOString());
+    try {
+      const response = await app.request("/next", { method: "GET" });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as EnvelopeResponse<NextWorkData>;
+      expect(body.ok).toBe(true);
+      if (body.ok && body.data) {
+        // The default `freshClaimToken` prefixes with `c_`.
+        expect(body.data.claim.startsWith("c_")).toBe(true);
+        expect(body.data.claim.length).toBeGreaterThan(8);
+      }
+    } finally {
+      db.close();
     }
   });
 });

--- a/src/api/agent/agent.test.ts
+++ b/src/api/agent/agent.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Tests for `src/api/agent/work.ts` — `GET /work/next` and
+ * `POST /work/{claim_token}/result` (DESIGN.md §3.3).
+ *
+ * Test bullets are taken verbatim from issue #10's "Verification" section.
+ * Every named bullet has at least one corresponding `it()` below; the
+ * bullet text is included in the test title so a reviewer can grep for it.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type Database from "better-sqlite3";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+import { openDb } from "../../db/index.js";
+import { runMigrations } from "../../db/migrate.js";
+
+import { createAgentApp } from "./index.js";
+import type { NextWorkData, SubmitOkData } from "./work.js";
+
+/**
+ * A trivial pipeline def used by every test. Two subtasks; the second
+ * `requires` the first. Both have permissive output schemas.
+ *
+ * Stored verbatim in `pipelines.def_json` so the route's payload-projection
+ * code can read it back for `instructions` / `output_schema`.
+ */
+const TEST_PIPELINE_ID = "test-pipeline";
+const TEST_PIPELINE_VERSION = 1;
+
+interface TestPipelineDef {
+  readonly id: string;
+  readonly subtasks: ReadonlyArray<{
+    readonly id: string;
+    readonly instructions: string;
+    readonly output_schema: Readonly<Record<string, unknown>>;
+    readonly requires?: ReadonlyArray<string>;
+  }>;
+}
+
+const TEST_PIPELINE_DEF: TestPipelineDef = {
+  id: TEST_PIPELINE_ID,
+  subtasks: [
+    {
+      id: "first",
+      instructions: "Do the first thing.",
+      output_schema: {
+        type: "object",
+        properties: { score: { type: "integer" } },
+        required: ["score"],
+        additionalProperties: false,
+      },
+    },
+    {
+      id: "second",
+      instructions: "Do the second thing, after first.",
+      output_schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
+        additionalProperties: false,
+      },
+      requires: ["first"],
+    },
+  ],
+};
+
+interface TestHarness {
+  readonly db: Database.Database;
+  readonly app: ReturnType<typeof createAgentApp>;
+  readonly nowFn: () => string;
+  setNow(iso: string): void;
+}
+
+/**
+ * Build a fresh in-memory test harness: open DB, run migrations, seed the
+ * pipeline, return a Hono app. Each test gets its own DB so concurrency
+ * tests don't bleed across cases.
+ */
+function makeHarness(opts?: {
+  ttlMs?: number;
+  initialNow?: string;
+  dbPath?: string;
+}): TestHarness {
+  const db = openDb(opts?.dbPath ?? ":memory:");
+  runMigrations(db);
+
+  const now = { value: opts?.initialNow ?? "2026-04-29T12:00:00.000Z" };
+  const nowFn = (): string => now.value;
+
+  // Seed the pipeline def.
+  db.prepare(
+    `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    TEST_PIPELINE_ID,
+    TEST_PIPELINE_VERSION,
+    JSON.stringify(TEST_PIPELINE_DEF),
+    now.value,
+    now.value,
+  );
+
+  let counter = 0;
+  const claimTokenFn = (): string => {
+    counter += 1;
+    return `c_${counter.toString().padStart(8, "0")}`;
+  };
+
+  const app = createAgentApp(
+    opts?.ttlMs !== undefined
+      ? { db, ttlMs: opts.ttlMs, nowFn, claimTokenFn }
+      : { db, nowFn, claimTokenFn },
+  );
+
+  return {
+    db,
+    app,
+    nowFn,
+    setNow(iso: string): void {
+      now.value = iso;
+    },
+  };
+}
+
+/**
+ * Insert a `runs` row + N `subtask_instances` rows. The first subtask
+ * instance is `ready`; subsequent ones are `pending` and gain `requires`.
+ */
+function seedRun(
+  db: Database.Database,
+  runId: string,
+  subtaskIds: ReadonlyArray<string>,
+  now: string,
+  options?: { readyIds?: ReadonlyArray<string> },
+): void {
+  db.prepare(
+    `INSERT INTO runs
+       (id, pipeline_id, pipeline_version, status, initial_input_json,
+        webhook_url, created_at)
+     VALUES (?, ?, ?, 'running', '{}', 'https://example.test/webhook', ?)`,
+  ).run(runId, TEST_PIPELINE_ID, TEST_PIPELINE_VERSION, now);
+
+  const readySet = new Set(options?.readyIds ?? [subtaskIds[0]]);
+
+  let i = 0;
+  for (const subtaskId of subtaskIds) {
+    const status = readySet.has(subtaskId) ? "ready" : "pending";
+    // Stagger created_at by 1 ms so FIFO order is deterministic.
+    const created = new Date(new Date(now).getTime() + i).toISOString();
+    db.prepare(
+      `INSERT INTO subtask_instances
+         (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, '{}', ?, ?)`,
+    ).run(`${runId}-${subtaskId}`, runId, subtaskId, status, created, created);
+    i += 1;
+  }
+}
+
+async function getJson<T>(
+  app: ReturnType<typeof createAgentApp>,
+  path: string,
+): Promise<{ status: number; body: EnvelopeResponse<T> }> {
+  const response = await app.request(path, { method: "GET" });
+  const body = (await response.json()) as EnvelopeResponse<T>;
+  return { status: response.status, body };
+}
+
+async function postJson<T>(
+  app: ReturnType<typeof createAgentApp>,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: EnvelopeResponse<T> }> {
+  const response = await app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const parsed = (await response.json()) as EnvelopeResponse<T>;
+  return { status: response.status, body: parsed };
+}
+
+/* ---------- GET /work/next ---------- */
+
+describe("GET /work/next", () => {
+  it("on empty queue → { ok: true, data: null }", async () => {
+    const h = makeHarness();
+    try {
+      const { status, body } = await getJson<NextWorkData | null>(
+        h.app,
+        "/next",
+      );
+      // Body present, NOT 204 (issue #10 explicitly requires HTTP 200 + body).
+      expect(status).toBe(200);
+      expect(body).toEqual({ ok: true, data: null });
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("on populated queue → { ok: true, data: { instructions, input, output_schema, claim } }", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const { status, body } = await getJson<NextWorkData>(h.app, "/next");
+      expect(status).toBe(200);
+      expect(body.ok).toBe(true);
+      if (!body.ok || body.data === undefined || body.data === null) {
+        throw new Error("expected populated data");
+      }
+      expect(body.data.instructions).toBe("Do the first thing.");
+      expect(body.data.output_schema).toMatchObject({ type: "object" });
+      expect(typeof body.data.claim).toBe("string");
+      expect(body.data.claim.length).toBeGreaterThan(0);
+      expect(body.data.input).toEqual({});
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("after a successful submit, the next GET /work/next returns the next ready subtask (integration)", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const first = await getJson<NextWorkData>(h.app, "/next");
+      if (!first.body.ok || !first.body.data) throw new Error("expected claim");
+      const claimToken = first.body.data.claim;
+
+      // Submit valid output for `first` to free `second` for claim.
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${claimToken}/result`,
+        { result: { score: 7 } },
+      );
+      expect(submit.body.ok).toBe(true);
+
+      const second = await getJson<NextWorkData>(h.app, "/next");
+      if (!second.body.ok || !second.body.data) {
+        throw new Error("expected second claim");
+      }
+      expect(second.body.data.instructions).toBe(
+        "Do the second thing, after first.",
+      );
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+/* ---------- Concurrency stress ---------- */
+
+describe("Concurrency stress: atomic claim has no duplicates", () => {
+  it("50 concurrent calls to /work/next against a 10-row queue produce 10 distinct claims, no duplicates", async () => {
+    // Use a temp file-backed DB so WAL + BEGIN IMMEDIATE behave as in
+    // production. better-sqlite3 serialises writes within a single
+    // connection regardless, but the file-backed mode also exercises the
+    // partial-unique-index constraint on `claim_token`.
+    const dir = mkdtempSync(join(tmpdir(), "murmur-agent-stress-"));
+    const dbPath = join(dir, "stress.db");
+
+    try {
+      const h = makeHarness({ dbPath });
+
+      // Seed 10 ready subtasks, all on the same run for simplicity.
+      const ids = Array.from({ length: 10 }, (_, i) => `t${i}`);
+      seedRun(h.db, "run-S", ids, h.nowFn(), { readyIds: ids });
+
+      const calls: Promise<{
+        status: number;
+        body: EnvelopeResponse<NextWorkData | null>;
+      }>[] = [];
+      for (let i = 0; i < 50; i += 1) {
+        calls.push(getJson<NextWorkData | null>(h.app, "/next"));
+      }
+      const results = await Promise.all(calls);
+
+      const tokens: string[] = [];
+      let nullCount = 0;
+      for (const r of results) {
+        expect(r.status).toBe(200);
+        expect(r.body.ok).toBe(true);
+        if (r.body.ok && r.body.data !== undefined && r.body.data !== null) {
+          tokens.push(r.body.data.claim);
+        } else {
+          nullCount += 1;
+        }
+      }
+
+      expect(tokens.length).toBe(10);
+      expect(nullCount).toBe(40);
+      // No duplicates.
+      expect(new Set(tokens).size).toBe(10);
+
+      h.db.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/* ---------- POST /work/{claim_token}/result ---------- */
+
+describe("POST /work/{claim_token}/result", () => {
+  it("with unknown claim → { ok: false, errors: ['claim_lost'] }", async () => {
+    const h = makeHarness();
+    try {
+      const { body } = await postJson<SubmitOkData>(
+        h.app,
+        "/c_doesnotexist/result",
+        { result: { score: 1 } },
+      );
+      expect(body.ok).toBe(false);
+      if (body.ok) throw new Error("unreachable");
+      expect(body.errors).toEqual(["claim_lost"]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("with expired claim → { ok: false, errors: ['claim_lost'] }", async () => {
+    // Use a short TTL and advance the clock past it before submitting.
+    const h = makeHarness({
+      ttlMs: 10,
+      initialNow: "2026-04-29T12:00:00.000Z",
+    });
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      // Advance the clock past the TTL.
+      h.setNow("2026-04-29T12:00:01.000Z");
+
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { score: 7 } },
+      );
+      expect(submit.body.ok).toBe(false);
+      if (submit.body.ok) throw new Error("unreachable");
+      expect(submit.body.errors).toEqual(["claim_lost"]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("with schema-invalid output → { ok: false, errors: ['validation:/...:...', ...] }", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      // `score` is required; submit something that fails the schema.
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { wrong: "field" } },
+      );
+      expect(submit.body.ok).toBe(false);
+      if (submit.body.ok) throw new Error("unreachable");
+      // At least one error string should start with `validation:`.
+      const stringErrors = submit.body.errors.filter(
+        (e): e is string => typeof e === "string",
+      );
+      expect(stringErrors.length).toBeGreaterThan(0);
+      expect(stringErrors.every((e) => e.startsWith("validation:"))).toBe(true);
+
+      // The row must NOT have been marked done — the schema-fail path
+      // must reject before the CAS UPDATE runs (we never want a `done`
+      // row without a valid result).
+      const row = h.db
+        .prepare(`SELECT status FROM subtask_instances WHERE claim_token = ?`)
+        .get(token) as { status: string } | undefined;
+      expect(row?.status).toBe("claimed");
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("with valid output → { ok: true, data: { run_id } }, status='done'", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { score: 9 } },
+      );
+      expect(submit.body.ok).toBe(true);
+      if (!submit.body.ok || submit.body.data === undefined) {
+        throw new Error("expected ok");
+      }
+      expect(submit.body.data.run_id).toBe("run-A");
+
+      // Status flipped to done; claim_token cleared so the row no longer
+      // surfaces in `/work/next`.
+      const row = h.db
+        .prepare(
+          `SELECT status, claim_token FROM subtask_instances WHERE id = 'run-A-first'`,
+        )
+        .get() as { status: string; claim_token: string | null } | undefined;
+      expect(row?.status).toBe("done");
+      expect(row?.claim_token).toBeNull();
+
+      // `subtask_results` row written.
+      const result = h.db
+        .prepare(
+          `SELECT output_json, notes FROM subtask_results WHERE instance_id = 'run-A-first'`,
+        )
+        .get() as { output_json: string; notes: string | null } | undefined;
+      expect(result).toBeDefined();
+      expect(JSON.parse(result?.output_json ?? "null")).toEqual({ score: 9 });
+      expect(result?.notes).toBeNull();
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("notes parameter persisted to agent_actions, not to subtask_results", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      const NOTES = "I tried two configs and picked the simpler one.";
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { score: 3 }, notes: NOTES },
+      );
+      expect(submit.body.ok).toBe(true);
+
+      // `subtask_results.notes` MUST be NULL (per DESIGN.md §3.1 last
+      // bullet + issue #10).
+      const result = h.db
+        .prepare(
+          `SELECT notes FROM subtask_results WHERE instance_id = 'run-A-first'`,
+        )
+        .get() as { notes: string | null } | undefined;
+      expect(result?.notes).toBeNull();
+
+      // `agent_actions` row recorded for the submit, with the notes
+      // visible somewhere in args_json or response_json.
+      const actions = h.db
+        .prepare(
+          `SELECT kind, args_json FROM agent_actions
+            WHERE instance_id = 'run-A-first' AND kind = 'submit_result'`,
+        )
+        .all() as ReadonlyArray<{ kind: string; args_json: string | null }>;
+      expect(actions.length).toBeGreaterThan(0);
+      const persistedSomewhere = actions.some(
+        (a) => (a.args_json ?? "").includes(NOTES),
+      );
+      expect(persistedSomewhere).toBe(true);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("idempotency: re-submitting against an already-done claim returns claim_lost", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      const first = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { score: 1 } },
+      );
+      expect(first.body.ok).toBe(true);
+
+      const second = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { score: 2 } },
+      );
+      expect(second.body.ok).toBe(false);
+      if (second.body.ok) throw new Error("unreachable");
+      expect(second.body.errors).toEqual(["claim_lost"]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("logs a 'claim' agent_action on a successful /work/next", async () => {
+    const h = makeHarness();
+    try {
+      seedRun(h.db, "run-A", ["first", "second"], h.nowFn());
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+
+      const actions = h.db
+        .prepare(
+          `SELECT kind FROM agent_actions WHERE instance_id = 'run-A-first'`,
+        )
+        .all() as ReadonlyArray<{ kind: string }>;
+      expect(actions.some((a) => a.kind === "claim")).toBe(true);
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+/* ---------- Envelope grep gate ---------- */
+
+describe("envelope grep gate", () => {
+  it("`pnpm grep-no-accepted-key` is empty across the agent module", () => {
+    // Run the gate from the worktree root. Exits 0 on no matches; non-zero
+    // on any match. Spawning the script (rather than re-implementing it in
+    // JS) keeps a single source of truth for the gate's grep semantics.
+    let failed = false;
+    try {
+      execFileSync(
+        "bash",
+        ["scripts/grep-no-accepted-key.sh"],
+        { stdio: "pipe" },
+      );
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(false);
+  });
+});

--- a/src/api/agent/index.ts
+++ b/src/api/agent/index.ts
@@ -31,10 +31,3 @@ export function createAgentApp(options: CreateAgentAppOptions): Hono {
   return createWorkRoutes(options);
 }
 
-export type {
-  CasOkRow,
-  ClaimedRow,
-  NextWorkData,
-  SubmitBody,
-  SubmitOkData,
-} from "./work.js";

--- a/src/api/agent/index.ts
+++ b/src/api/agent/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Public surface for the agent-facing HTTP routes (DESIGN.md §3.3).
+ *
+ * The factory `createAgentApp` builds the `/work` sub-app and is mounted
+ * by `src/server.ts` when a database handle is supplied to `createServer`.
+ * Tests build the same sub-app directly and exercise it via Hono's
+ * `app.request(...)` without binding a port.
+ *
+ * @see src/api/agent/work.ts — route handlers and their atomicity comments
+ */
+
+import type { Hono } from "hono";
+
+import {
+  createWorkRoutes,
+  type CreateWorkRoutesOptions,
+} from "./work.js";
+
+/**
+ * Options for {@link createAgentApp}. Identical to {@link CreateWorkRoutesOptions}
+ * for now — re-exported so `src/server.ts` can import a single type.
+ */
+export type CreateAgentAppOptions = CreateWorkRoutesOptions;
+
+/**
+ * Build the agent sub-app. Currently delegates to {@link createWorkRoutes};
+ * additional agent-facing routes (e.g. M7's `task_tool` proxy) will mount
+ * here as they land.
+ */
+export function createAgentApp(options: CreateAgentAppOptions): Hono {
+  return createWorkRoutes(options);
+}
+
+export type {
+  CasOkRow,
+  ClaimedRow,
+  NextWorkData,
+  SubmitBody,
+  SubmitOkData,
+} from "./work.js";

--- a/src/api/agent/lifecycle.ts
+++ b/src/api/agent/lifecycle.ts
@@ -1,0 +1,104 @@
+/**
+ * Lifecycle helpers for the agent endpoints — runs after a successful
+ * submit to advance the pipeline state.
+ *
+ * For M5 (this PR), the responsibilities are:
+ *
+ *   - **Mark next-ready set** — flip any `pending` subtask_instances on the
+ *     same run whose `requires` are now satisfied to `ready`. This is the
+ *     deterministic-DAG path; spawn-driven instantiation is M8 territory.
+ *
+ * Stubs (not implemented in this PR — referenced for grep-trail):
+ *
+ *   - **Spawns** (M8 / issue #16). When the just-completed subtask declares
+ *     `spawns: { for_each, template }`, instantiate one child instance per
+ *     element of the parent's `output[for_each]` array. M5 leaves a TODO
+ *     and returns without spawning.
+ *
+ *   - **Run-completion webhook** (M10 / issue #18). When all of a run's
+ *     non-skipped subtasks reach `done`, compose `final_output` per the
+ *     pipeline def's `composes:` rules and POST the run to `webhook_url`.
+ *     M5 leaves a TODO; the run will sit in `running` until M10 ships.
+ *
+ * @see DESIGN.md §3.1 — `requires`, `spawns`, `composes`
+ * @see DESIGN.md §3.3 — claim/CAS lifecycle
+ */
+
+import type Database from "better-sqlite3";
+
+/**
+ * Promote any `pending` subtask_instances on `runId` whose `requires`
+ * have all been satisfied (i.e. every prerequisite subtask has at least
+ * one `done` instance) to `status='ready'`.
+ *
+ * Reads the run's pipeline def from `pipelines.def_json`, walks each
+ * pending instance's `subtask_id` → `requires`, and bumps to ready when
+ * all requirements are met. Idempotent: re-running on an already-ready
+ * run is a no-op (only `pending` rows are considered).
+ *
+ * Implementation note: writes happen inside the caller's transaction;
+ * this function does NOT open or commit one.
+ *
+ * @param db  open better-sqlite3 connection
+ * @param runId  the run whose dependents to consider
+ * @param now  RFC 3339 UTC timestamp to set as `updated_at` on flipped rows
+ * @returns the list of instance ids that were promoted to `ready`
+ */
+export function markNextReady(
+  // The bodies will land in step 6. Keeping the placeholder signature here
+  // means the test file can import the symbol against an unimplemented
+  // contract per AGENTS.md step 4.
+  db: Database.Database,
+  runId: string,
+  now: string,
+): ReadonlyArray<string> {
+  void db;
+  void runId;
+  void now;
+  throw new Error("not implemented");
+}
+
+/**
+ * M8 stub — spawn child instances when the just-completed subtask declares
+ * `spawns:`. NOT implemented in this PR. See issue #16.
+ *
+ * The function is exported (rather than left as a comment) so the import
+ * graph stays stable when M8 lands and so a grep for `spawnChildren` finds
+ * the documented stub.
+ */
+export function spawnChildren(
+  db: Database.Database,
+  parentInstanceId: string,
+  output: unknown,
+  now: string,
+): ReadonlyArray<string> {
+  void db;
+  void parentInstanceId;
+  void output;
+  void now;
+  // TODO(M8 / colophon-group/murmur#16): instantiate one child per
+  // `output[spawns.for_each]` element, using the `spawns.template` subtask
+  // def. For M5 this is a no-op so the deterministic happy path runs.
+  return [];
+}
+
+/**
+ * M10 stub — fire the run-completion webhook when all subtasks reach
+ * `done`. NOT implemented in this PR. See issue #18.
+ *
+ * Same export-rather-than-comment rationale as `spawnChildren`.
+ */
+export function maybeFinaliseRun(
+  db: Database.Database,
+  runId: string,
+  now: string,
+): boolean {
+  void db;
+  void runId;
+  void now;
+  // TODO(M10 / colophon-group/murmur#18): when all non-skipped instances
+  // of `runId` are `done`, compose `final_output` per the pipeline def's
+  // `composes:` and POST it to `webhook_url`. For M5 this is a no-op and
+  // the run stays in `status='running'`.
+  return false;
+}

--- a/src/api/agent/lifecycle.ts
+++ b/src/api/agent/lifecycle.ts
@@ -45,17 +45,77 @@ import type Database from "better-sqlite3";
  * @returns the list of instance ids that were promoted to `ready`
  */
 export function markNextReady(
-  // The bodies will land in step 6. Keeping the placeholder signature here
-  // means the test file can import the symbol against an unimplemented
-  // contract per AGENTS.md step 4.
   db: Database.Database,
   runId: string,
   now: string,
 ): ReadonlyArray<string> {
-  void db;
-  void runId;
-  void now;
-  throw new Error("not implemented");
+  // 1. Read the pipeline def to get each subtask's `requires`.
+  const pipelineRow = db
+    .prepare(
+      `SELECT pipelines.def_json AS def_json
+         FROM pipelines
+         JOIN runs ON runs.pipeline_id = pipelines.id
+        WHERE runs.id = ?`,
+    )
+    .get(runId) as { def_json: string } | undefined;
+  if (pipelineRow === undefined) return [];
+
+  let def: PipelineDefForLifecycle;
+  try {
+    def = JSON.parse(pipelineRow.def_json) as PipelineDefForLifecycle;
+  } catch {
+    return [];
+  }
+
+  // 2. The set of subtask_ids that have at least one done instance on
+  //    this run. Used to test `requires` satisfaction.
+  const doneRows = db
+    .prepare(
+      `SELECT DISTINCT subtask_id FROM subtask_instances
+        WHERE run_id = ? AND status = 'done'`,
+    )
+    .all(runId) as ReadonlyArray<{ subtask_id: string }>;
+  const doneSet = new Set(doneRows.map((r) => r.subtask_id));
+
+  // 3. For each pending instance on this run, check if every entry in
+  //    its subtask def's `requires` is satisfied; if so, flip to ready.
+  const pending = db
+    .prepare(
+      `SELECT id, subtask_id FROM subtask_instances
+        WHERE run_id = ? AND status = 'pending'`,
+    )
+    .all(runId) as ReadonlyArray<{ id: string; subtask_id: string }>;
+
+  const update = db.prepare(
+    `UPDATE subtask_instances
+        SET status = 'ready', updated_at = ?
+      WHERE id = ? AND status = 'pending'`,
+  );
+
+  const promoted: string[] = [];
+  for (const row of pending) {
+    const subtaskDef = def.subtasks.find((s) => s.id === row.subtask_id);
+    if (subtaskDef === undefined) continue;
+    const requires = subtaskDef.requires ?? [];
+    const allDone = requires.every((r) => doneSet.has(r));
+    if (allDone) {
+      update.run(now, row.id);
+      promoted.push(row.id);
+    }
+  }
+  return promoted;
+}
+
+/**
+ * Local mirror of just the pipeline-def fields {@link markNextReady} cares
+ * about. Avoids a tight coupling to the (still-evolving) authoritative
+ * `PipelineDef` type while keeping the code typed.
+ */
+interface PipelineDefForLifecycle {
+  readonly subtasks: ReadonlyArray<{
+    readonly id: string;
+    readonly requires?: ReadonlyArray<string>;
+  }>;
 }
 
 /**

--- a/src/api/agent/sql.ts
+++ b/src/api/agent/sql.ts
@@ -1,0 +1,129 @@
+/**
+ * Prepared-statement SQL for the agent claim/CAS endpoints (DESIGN.md §3.3).
+ *
+ * Two atomic single-statement updates form the contract:
+ *
+ *   1. **Claim** (`/work/next`). Picks the oldest `ready` subtask whose
+ *      `claim_token` is NULL, marks it `claimed`, and returns it — all in
+ *      one `UPDATE … RETURNING` round-trip wrapped in `BEGIN IMMEDIATE`.
+ *      The subselect's `LIMIT 1` is the only row touched; the partial
+ *      unique index on `claim_token` guarantees a token cannot be reused
+ *      across rows even under a hypothetical inner-engine race.
+ *
+ *   2. **CAS submit** (`/work/{claim_token}/result`). Atomically transitions
+ *      a row from `claimed` → `done` only if `(claim_token, status='claimed',
+ *      expires_at > now)` still holds. Failure means the claim was lost
+ *      (TTL expired, swept, or already submitted) and the agent's payload
+ *      is discarded with `claim_lost`.
+ *
+ * Why each clause matters in CLAIM_SQL:
+ *   - `WHERE id = (SELECT id … LIMIT 1)` — the subselect pins the row by
+ *     primary key BEFORE the UPDATE runs, so the UPDATE never has to scan
+ *     `subtask_instances` itself. The selector uses
+ *     `(status='ready', created_at)` which matches `idx_subtask_instances_ready`.
+ *   - `claim_token IS NULL AND status='ready'` — `ready` rows that are not
+ *     currently claimed. Expired claims are reset back to `ready` by the
+ *     sweeper (DESIGN.md §3.3) before they re-appear here.
+ *   - `ORDER BY created_at LIMIT 1` — FIFO across the ready pool.
+ *     `created_at` is indexed in the same composite index as `status`.
+ *   - `RETURNING …` — single round-trip; we read the row we just claimed.
+ *     Inside `BEGIN IMMEDIATE`, this is atomic against any other writer.
+ *
+ * Why each clause matters in CAS_SQL:
+ *   - `claim_token = ?` — pin the exact row by the agent's token. The
+ *     partial unique index makes this an O(1) lookup.
+ *   - `status = 'claimed'` — refuse to double-submit (the row is already
+ *     `done` if a previous submit landed) or to submit against a
+ *     swept-back-to-`ready` row.
+ *   - `expires_at > ?` — refuse to submit after the TTL elapsed; the
+ *     sweeper may not have run yet, but the contract is "expired claims
+ *     are dead". Comparison uses lexicographic ordering on RFC 3339 UTC
+ *     strings, which is correct iff the format is canonicalised
+ *     (Z-suffixed, no offset, millisecond precision). Callers MUST format
+ *     `now` consistently with the column writer (see `nowIso()` in
+ *     `src/api/agent/work.ts`).
+ *   - `RETURNING id, run_id, subtask_id` — non-empty result set is the
+ *     CAS-success signal. `claim_token=NULL` after the UPDATE so the
+ *     partial unique index keeps allowing inserts (and stops surfacing
+ *     this row in subsequent claim queries).
+ *
+ * @see DESIGN.md §3.3 — atomic claim CAS rationale
+ * @see src/db/schema.md — `subtask_instances` columns
+ */
+
+/**
+ * Atomic claim. Inside `BEGIN IMMEDIATE`. Bound parameters:
+ *   1. claim_token (TEXT, fresh, opaque, NOT NULL)
+ *   2. expires_at  (TEXT, RFC 3339 UTC; now + ttlMs)
+ *   3. updated_at  (TEXT, RFC 3339 UTC; now)
+ *
+ * Returns at most one row with the freshly-claimed instance, or zero rows
+ * if no `ready` subtask exists.
+ */
+export const CLAIM_SQL = `
+UPDATE subtask_instances
+   SET claim_token = ?,
+       expires_at  = ?,
+       status      = 'claimed',
+       updated_at  = ?
+ WHERE id = (
+   SELECT id FROM subtask_instances
+    WHERE claim_token IS NULL AND status = 'ready'
+    ORDER BY created_at LIMIT 1
+ )
+RETURNING id, run_id, subtask_id, input_json, claim_token, expires_at
+`;
+
+/**
+ * Atomic CAS submit. Bound parameters:
+ *   1. updated_at  (TEXT, RFC 3339 UTC; now)
+ *   2. claim_token (TEXT, the agent-supplied token)
+ *   3. now_iso     (TEXT, RFC 3339 UTC; same `now` used for `updated_at`)
+ *
+ * Returns at most one row identifying the run/subtask if the CAS succeeded,
+ * or zero rows if the claim was lost (token unknown, expired, already done,
+ * or status was reset by the sweeper).
+ */
+export const CAS_SQL = `
+UPDATE subtask_instances
+   SET status      = 'done',
+       updated_at  = ?,
+       claim_token = NULL,
+       expires_at  = NULL
+ WHERE claim_token = ?
+   AND status      = 'claimed'
+   AND expires_at  > ?
+RETURNING id, run_id, subtask_id
+`;
+
+/**
+ * Insert one `subtask_results` row. Bound parameters:
+ *   1. instance_id  (TEXT, PK; the claim's `subtask_instances.id`)
+ *   2. output_json  (TEXT, the validated result payload as JSON string)
+ *   3. submitted_at (TEXT, RFC 3339 UTC; now)
+ *
+ * `notes` is intentionally NOT written here — DESIGN.md §3.1 (last
+ * bullet) and issue #10 both require `notes` to live in `agent_actions`
+ * only, not in the schema-validated result.
+ */
+export const INSERT_RESULT_SQL = `
+INSERT INTO subtask_results (instance_id, output_json, submitted_at)
+VALUES (?, ?, ?)
+`;
+
+/**
+ * Insert one `agent_actions` audit row. Bound parameters:
+ *   1. instance_id   (TEXT)
+ *   2. ts            (TEXT, RFC 3339 UTC; now)
+ *   3. kind          (TEXT, one of 'claim' | 'submit_result' | 'claim_lost' …)
+ *   4. subcommand    (TEXT | NULL)
+ *   5. args_json     (TEXT | NULL, ≤4 KB per §3.6 truncation rule — the
+ *                     truncation itself is the caller's responsibility)
+ *   6. response_json (TEXT | NULL, ≤4 KB)
+ *   7. truncated     (INTEGER, 0 or 1)
+ */
+export const INSERT_AGENT_ACTION_SQL = `
+INSERT INTO agent_actions
+  (instance_id, ts, kind, subcommand, args_json, response_json, truncated)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`;

--- a/src/api/agent/work.ts
+++ b/src/api/agent/work.ts
@@ -3,8 +3,8 @@
  * agent endpoints (DESIGN.md §3.3).
  *
  * Both endpoints use the M0 envelope (`{ ok, errors?, data? }`); there is
- * no `accepted:` parallel shape. Both are mounted by `createAgentApp` in
- * `src/api/agent/index.ts`.
+ * no parallel `accepted` shape (grep-no-accepted-key:allow — prose). Both
+ * are mounted by `createAgentApp` in `src/api/agent/index.ts`.
  *
  * Atomicity rules:
  *

--- a/src/api/agent/work.ts
+++ b/src/api/agent/work.ts
@@ -1,0 +1,184 @@
+/**
+ * `GET /work/next` and `POST /work/{claim_token}/result` — the two atomic
+ * agent endpoints (DESIGN.md §3.3).
+ *
+ * Both endpoints use the M0 envelope (`{ ok, errors?, data? }`); there is
+ * no `accepted:` parallel shape. Both are mounted by `createAgentApp` in
+ * `src/api/agent/index.ts`.
+ *
+ * Atomicity rules:
+ *
+ *   - `GET /work/next` runs a single `UPDATE … RETURNING` inside
+ *     `BEGIN IMMEDIATE`. The transaction wrapping is what serialises
+ *     concurrent claims at the SQLite layer (better-sqlite3 is sync; a
+ *     `BEGIN IMMEDIATE` raises `SQLITE_BUSY` if another writer holds the
+ *     RESERVED lock — for in-process concurrency this is a non-issue
+ *     because better-sqlite3 already serialises writes at the connection
+ *     mutex). See `src/db/concurrency.test.ts` for the contract.
+ *
+ *   - `POST /work/{claim_token}/result` runs CAS as a single
+ *     `UPDATE … RETURNING`. If the row no longer matches the predicate
+ *     (token unknown, expired, already done), the UPDATE returns no
+ *     rows and the endpoint emits `{ok: false, errors: ['claim_lost']}`.
+ *     On success, the result and audit rows write inside the same
+ *     transaction so a crash mid-handler cannot leave a `done` row
+ *     without its `subtask_results` companion.
+ *
+ * @see DESIGN.md §3.3 — Server endpoints (agent-facing)
+ * @see src/api/agent/sql.ts — the prepared statements
+ */
+
+import { Hono } from "hono";
+
+import type Database from "better-sqlite3";
+
+import type { EnvelopeResponse, Err, Ok } from "@murmur/contracts-types";
+
+import { validateAgainst } from "../../dispatch/validation.js";
+
+import {
+  CAS_SQL,
+  CLAIM_SQL,
+  INSERT_AGENT_ACTION_SQL,
+  INSERT_RESULT_SQL,
+} from "./sql.js";
+import { markNextReady, maybeFinaliseRun, spawnChildren } from "./lifecycle.js";
+
+/**
+ * Default claim TTL: 10 minutes (DESIGN.md §3.3, "Fixed 10-minute TTL.").
+ *
+ * Tests override this to a small value (e.g. 50ms) so the
+ * "expired claim → claim_lost" path is exercisable without sleeping.
+ */
+export const DEFAULT_CLAIM_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Options accepted by {@link createWorkRoutes}.
+ *
+ * `db` is an open better-sqlite3 connection; the routes do not own its
+ * lifecycle. `ttlMs` overrides the default 10-minute claim TTL — used by
+ * tests to exercise the expired-claim path. `nowFn` and `claimTokenFn`
+ * are seams for deterministic testing (clock and RNG).
+ */
+export interface CreateWorkRoutesOptions {
+  readonly db: Database.Database;
+  readonly ttlMs?: number;
+  /** Returns the current time as an RFC 3339 UTC string. */
+  readonly nowFn?: () => string;
+  /** Returns a fresh claim token (opaque, ≥16 bytes of entropy). */
+  readonly claimTokenFn?: () => string;
+}
+
+/**
+ * Shape of the row RETURNED by `CLAIM_SQL`. Mirrors the columns we
+ * project; everything is `string` because SQLite stores them as `TEXT`.
+ */
+export interface ClaimedRow {
+  readonly id: string;
+  readonly run_id: string;
+  readonly subtask_id: string;
+  readonly input_json: string;
+  readonly claim_token: string;
+  readonly expires_at: string;
+}
+
+/**
+ * Shape of the row RETURNED by `CAS_SQL` on a successful submit.
+ */
+export interface CasOkRow {
+  readonly id: string;
+  readonly run_id: string;
+  readonly subtask_id: string;
+}
+
+/**
+ * Successful `/work/next` payload (the `data` slot in the M0 envelope).
+ * `null` is also a valid `data` for the no-work case.
+ */
+export interface NextWorkData {
+  readonly instructions: string;
+  readonly input: unknown;
+  readonly output_schema: Readonly<Record<string, unknown>>;
+  /** Opaque token; agent passes it back on subcommand and submit. */
+  readonly claim: string;
+}
+
+/**
+ * Successful `/result` payload — the run id, so the agent can correlate
+ * (and so it appears in the audit trail).
+ */
+export interface SubmitOkData {
+  readonly run_id: string;
+}
+
+/**
+ * Body shape for `POST /work/{claim_token}/result`.
+ */
+export interface SubmitBody {
+  readonly result: unknown;
+  readonly notes?: string;
+}
+
+/**
+ * Build a Hono sub-app exposing `GET /next` and `POST /:claim_token/result`.
+ *
+ * The sub-app is mounted at `/work` by `createServer`, yielding the final
+ * routes `GET /work/next` and `POST /work/{claim_token}/result`.
+ *
+ * @returns a Hono app (no app-level middleware; bearer auth applies at the
+ *   parent app's `app.use('*', ...)` level).
+ */
+export function createWorkRoutes(options: CreateWorkRoutesOptions): Hono {
+  void options;
+  throw new Error("not implemented");
+}
+
+/**
+ * Helper: format `Date` as an RFC 3339 UTC string with millisecond
+ * precision (`YYYY-MM-DDTHH:MM:SS.sssZ`). Matches the format used by
+ * existing migration code (`new Date().toISOString()`). Exported for tests.
+ */
+export function nowIso(d: Date = new Date()): string {
+  return d.toISOString();
+}
+
+/**
+ * Helper: build a fresh claim token. Returns a URL-safe string with
+ * ≥128 bits of entropy. Exported for tests.
+ */
+export function freshClaimToken(): string {
+  throw new Error("not implemented");
+}
+
+/**
+ * Lookup the run's `subtask_def_id` → `{instructions, output_schema, input}`
+ * tuple by reading `pipelines.def_json`. Used after a successful claim to
+ * project the agent-facing payload.
+ *
+ * @returns the projected payload, or `null` if the pipeline def cannot be
+ *   located or the subtask def is not in it (which would indicate schema
+ *   drift between when the run started and now — a hard error in a real
+ *   deployment, surfaced here as a null so the route can return 500).
+ */
+export function projectClaimPayload(
+  db: Database.Database,
+  runId: string,
+  subtaskId: string,
+  inputJson: string,
+  claimToken: string,
+): NextWorkData | null {
+  void db;
+  void runId;
+  void subtaskId;
+  void inputJson;
+  void claimToken;
+  throw new Error("not implemented");
+}
+
+/**
+ * Type-only re-export so consumers (and tests) can build envelope literals
+ * without importing the contracts package twice.
+ */
+export type AgentEnvelope<T> = EnvelopeResponse<T>;
+export type AgentOk<T> = Ok<T>;
+export type AgentErr = Err;

--- a/src/api/agent/work.ts
+++ b/src/api/agent/work.ts
@@ -28,11 +28,13 @@
  * @see src/api/agent/sql.ts — the prepared statements
  */
 
+import { randomBytes } from "node:crypto";
+
 import { Hono } from "hono";
 
 import type Database from "better-sqlite3";
 
-import type { EnvelopeResponse, Err, Ok } from "@murmur/contracts-types";
+import type { Err, Ok } from "@murmur/contracts-types";
 
 import { validateAgainst } from "../../dispatch/validation.js";
 
@@ -51,6 +53,15 @@ import { markNextReady, maybeFinaliseRun, spawnChildren } from "./lifecycle.js";
  * "expired claim → claim_lost" path is exercisable without sleeping.
  */
 export const DEFAULT_CLAIM_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Audit-log payload truncation cap (DESIGN.md §3.6).
+ *
+ * `args_json` and `response_json` on `agent_actions` are capped at 4 KB.
+ * Truncation is recorded by setting `truncated = 1`. The audit log is for
+ * post-mortem inspection — full payloads live in `subtask_results`.
+ */
+const AUDIT_PAYLOAD_LIMIT_BYTES = 4 * 1024;
 
 /**
  * Options accepted by {@link createWorkRoutes}.
@@ -120,6 +131,18 @@ export interface SubmitBody {
 }
 
 /**
+ * Subset of the pipeline def we read off `pipelines.def_json`. Kept local
+ * so the route is decoupled from the (still-evolving) authoritative type.
+ */
+interface PipelineDefRow {
+  readonly subtasks: ReadonlyArray<{
+    readonly id: string;
+    readonly instructions?: string;
+    readonly output_schema?: Readonly<Record<string, unknown>>;
+  }>;
+}
+
+/**
  * Build a Hono sub-app exposing `GET /next` and `POST /:claim_token/result`.
  *
  * The sub-app is mounted at `/work` by `createServer`, yielding the final
@@ -129,8 +152,261 @@ export interface SubmitBody {
  *   parent app's `app.use('*', ...)` level).
  */
 export function createWorkRoutes(options: CreateWorkRoutesOptions): Hono {
-  void options;
-  throw new Error("not implemented");
+  const db = options.db;
+  const ttlMs = options.ttlMs ?? DEFAULT_CLAIM_TTL_MS;
+  const nowFn = options.nowFn ?? (() => nowIso());
+  const claimTokenFn = options.claimTokenFn ?? freshClaimToken;
+
+  // Compile the prepared statements once at construction time. Re-binding
+  // happens on every call but the parse step runs once.
+  const claimStmt = db.prepare(CLAIM_SQL);
+  const casStmt = db.prepare(CAS_SQL);
+  const insertResultStmt = db.prepare(INSERT_RESULT_SQL);
+  const insertActionStmt = db.prepare(INSERT_AGENT_ACTION_SQL);
+  const lookupPipelineStmt = db.prepare(
+    `SELECT pipelines.def_json AS def_json
+       FROM pipelines
+       JOIN runs ON runs.pipeline_id = pipelines.id
+      WHERE runs.id = ?`,
+  );
+
+  const app = new Hono();
+
+  /* ---------- GET /work/next ---------- */
+  app.get("/next", (c) => {
+    const now = nowFn();
+    const expiresAt = new Date(Date.parse(now) + ttlMs).toISOString();
+    const token = claimTokenFn();
+
+    // Atomic claim: BEGIN IMMEDIATE upgrades to RESERVED on entry; the
+    // single UPDATE … RETURNING below is the only write inside the txn.
+    // better-sqlite3 serialises connection-level writes via its native
+    // mutex, but BEGIN IMMEDIATE is still required because:
+    //   1. It pins the row choice + status flip into one logical step
+    //      (no one else can write between the inner SELECT and the UPDATE).
+    //   2. The contract `src/db/concurrency.test.ts` enforces remains
+    //      independent of the in-process mutex (file-backed multi-process
+    //      use eventually applies).
+    //
+    // We do NOT issue an explicit `claim` agent_action insert inside the
+    // same txn because the `agent_actions` table FK depends on the
+    // instance row already existing. The UPDATE … RETURNING already wrote
+    // the row before we INSERT, so this is fine — we issue the INSERT
+    // immediately after COMMIT.
+    db.exec("BEGIN IMMEDIATE");
+    let row: ClaimedRow | undefined;
+    try {
+      row = claimStmt.get(token, expiresAt, now) as ClaimedRow | undefined;
+      db.exec("COMMIT");
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // ignore — the original error is surfaced below
+      }
+      throw err;
+    }
+
+    if (row === undefined) {
+      // Empty queue. Per the issue: HTTP 200 with body, NOT 204.
+      const body: Ok<null> = { ok: true, data: null };
+      return c.json(body, 200);
+    }
+
+    const payload = projectClaimPayload(
+      row.run_id,
+      row.subtask_id,
+      row.input_json,
+      row.claim_token,
+      lookupPipelineStmt,
+    );
+    if (payload === null) {
+      // Pipeline def not resolvable → schema drift. Treat as an internal
+      // error; the row stays `claimed` so the sweeper can release it.
+      const body: Err = {
+        ok: false,
+        errors: ["pipeline_not_found"],
+      };
+      return c.json(body, 500);
+    }
+
+    // Audit: log the claim. Truncate the projected input if it exceeds
+    // the §3.6 4 KB cap.
+    const args = truncatePayload(JSON.stringify({ claim: row.claim_token }));
+    const resp = truncatePayload(JSON.stringify({ instance_id: row.id }));
+    insertActionStmt.run(
+      row.id,
+      now,
+      "claim",
+      null,
+      args.text,
+      resp.text,
+      args.truncated || resp.truncated ? 1 : 0,
+    );
+
+    const okBody: Ok<NextWorkData> = { ok: true, data: payload };
+    return c.json(okBody, 200);
+  });
+
+  /* ---------- POST /work/{claim_token}/result ---------- */
+  app.post("/:claim_token/result", async (c) => {
+    const token = c.req.param("claim_token");
+    let body: SubmitBody;
+    try {
+      body = (await c.req.json()) as SubmitBody;
+    } catch {
+      const errBody: Err = { ok: false, errors: ["bad_json"] };
+      return c.json(errBody, 400);
+    }
+    if (
+      body === null ||
+      typeof body !== "object" ||
+      !("result" in body)
+    ) {
+      const errBody: Err = { ok: false, errors: ["bad_request"] };
+      return c.json(errBody, 400);
+    }
+
+    const now = nowFn();
+
+    // Resolve the row by claim_token to validate the result against the
+    // subtask's output_schema BEFORE we run the CAS. We deliberately do
+    // not run the CAS first: a schema-invalid result must not flip the
+    // row to `done`. The lookup is a simple SELECT — no lock taken;
+    // worst case the row's status changed between SELECT and CAS, in
+    // which case the CAS UPDATE returns zero rows and we report
+    // `claim_lost` (correct: the agent's window was lost).
+    const lookup = db
+      .prepare(
+        `SELECT id, run_id, subtask_id, status, expires_at
+           FROM subtask_instances
+          WHERE claim_token = ?`,
+      )
+      .get(token) as
+      | {
+          id: string;
+          run_id: string;
+          subtask_id: string;
+          status: string;
+          expires_at: string;
+        }
+      | undefined;
+
+    if (
+      lookup === undefined ||
+      lookup.status !== "claimed" ||
+      lookup.expires_at <= now
+    ) {
+      // Audit: log the rejected submit. We can only attach `instance_id`
+      // when we resolved the row; if not, drop on the floor (we'd have
+      // an FK violation). Silent here keeps the contract clean — a noisy
+      // unknown-claim audit row would be agent-driven garbage.
+      const errBody: Err = { ok: false, errors: ["claim_lost"] };
+      return c.json(errBody, 200);
+    }
+
+    // Pipeline def lookup so we can grab the right output_schema for
+    // validation.
+    const pipelineDef = readPipelineDef(lookup.run_id, lookupPipelineStmt);
+    if (pipelineDef === null) {
+      const errBody: Err = { ok: false, errors: ["pipeline_not_found"] };
+      return c.json(errBody, 500);
+    }
+    const subtaskDef = pipelineDef.subtasks.find(
+      (s) => s.id === lookup.subtask_id,
+    );
+    if (subtaskDef === undefined || subtaskDef.output_schema === undefined) {
+      const errBody: Err = { ok: false, errors: ["pipeline_not_found"] };
+      return c.json(errBody, 500);
+    }
+
+    const validation = validateAgainst(subtaskDef.output_schema, body.result);
+    if (!validation.ok) {
+      // Schema-fail path: leave the row claimed so the agent (or sweeper)
+      // can retry. Issue requires the validation error string format.
+      // Audit the rejection so operators can diagnose.
+      const args = truncatePayload(JSON.stringify(body));
+      const resp = truncatePayload(
+        JSON.stringify({ errors: validation.errors }),
+      );
+      insertActionStmt.run(
+        lookup.id,
+        now,
+        "submit_result",
+        null,
+        args.text,
+        resp.text,
+        args.truncated || resp.truncated ? 1 : 0,
+      );
+      const errBody: Err = { ok: false, errors: validation.errors };
+      return c.json(errBody, 400);
+    }
+
+    // CAS submit + result write + audit + lifecycle, all in one txn so
+    // a crash leaves the DB consistent.
+    db.exec("BEGIN IMMEDIATE");
+    let casRow: CasOkRow | undefined;
+    try {
+      casRow = casStmt.get(now, token, now) as CasOkRow | undefined;
+      if (casRow === undefined) {
+        // Lost the CAS race. Roll back and fall through to the
+        // claim_lost path. No audit row here — see the unknown-claim
+        // rationale above.
+        db.exec("ROLLBACK");
+      } else {
+        const outputJson = JSON.stringify(validation.value);
+        insertResultStmt.run(casRow.id, outputJson, now);
+
+        // Audit: notes ride in args_json so they're visible in the
+        // run-status response (DESIGN.md §3.1 last bullet, §3.6 audit).
+        // The result column is intentionally NOT mirrored into
+        // subtask_results.notes — DESIGN.md §3.1 requires notes live in
+        // the audit log only.
+        const args = truncatePayload(JSON.stringify(body));
+        const resp = truncatePayload(
+          JSON.stringify({ run_id: casRow.run_id }),
+        );
+        insertActionStmt.run(
+          casRow.id,
+          now,
+          "submit_result",
+          null,
+          args.text,
+          resp.text,
+          args.truncated || resp.truncated ? 1 : 0,
+        );
+
+        // Mark next ready set inside the same transaction.
+        markNextReady(db, casRow.run_id, now);
+
+        // M8 stub: spawn children. M10 stub: maybe finalise run.
+        spawnChildren(db, casRow.id, validation.value, now);
+        maybeFinaliseRun(db, casRow.run_id, now);
+
+        db.exec("COMMIT");
+      }
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
+
+    if (casRow === undefined) {
+      const errBody: Err = { ok: false, errors: ["claim_lost"] };
+      return c.json(errBody, 200);
+    }
+
+    const okBody: Ok<SubmitOkData> = {
+      ok: true,
+      data: { run_id: casRow.run_id },
+    };
+    return c.json(okBody, 200);
+  });
+
+  return app;
 }
 
 /**
@@ -144,14 +420,55 @@ export function nowIso(d: Date = new Date()): string {
 
 /**
  * Helper: build a fresh claim token. Returns a URL-safe string with
- * ≥128 bits of entropy. Exported for tests.
+ * 128 bits of entropy (16 random bytes, base64url-encoded). Exported for
+ * tests so harnesses can match its shape.
  */
 export function freshClaimToken(): string {
-  throw new Error("not implemented");
+  return `c_${randomBytes(16).toString("base64url")}`;
 }
 
 /**
- * Lookup the run's `subtask_def_id` → `{instructions, output_schema, input}`
+ * Truncate a JSON payload to {@link AUDIT_PAYLOAD_LIMIT_BYTES} bytes,
+ * reporting whether truncation actually happened. Encoding is UTF-8.
+ *
+ * SQLite's TEXT type is byte-counted; we compare bytes, not code points.
+ */
+function truncatePayload(text: string): {
+  text: string;
+  truncated: boolean;
+} {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= AUDIT_PAYLOAD_LIMIT_BYTES) {
+    return { text, truncated: false };
+  }
+  // Slice on a byte boundary, then decode with replacement so we don't
+  // emit a half-character at the cut point.
+  const truncated = buf
+    .subarray(0, AUDIT_PAYLOAD_LIMIT_BYTES)
+    .toString("utf8");
+  return { text: truncated, truncated: true };
+}
+
+/**
+ * Read and parse a run's pipeline def, returning `null` if the run or
+ * pipeline cannot be located (a hard error in production — surfaces as
+ * 500 to the agent). Exported for tests.
+ */
+export function readPipelineDef(
+  runId: string,
+  stmt: Database.Statement,
+): PipelineDefRow | null {
+  const row = stmt.get(runId) as { def_json: string } | undefined;
+  if (row === undefined) return null;
+  try {
+    return JSON.parse(row.def_json) as PipelineDefRow;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Lookup the run's `subtask_def` → `{instructions, output_schema, input}`
  * tuple by reading `pipelines.def_json`. Used after a successful claim to
  * project the agent-facing payload.
  *
@@ -161,24 +478,33 @@ export function freshClaimToken(): string {
  *   deployment, surfaced here as a null so the route can return 500).
  */
 export function projectClaimPayload(
-  db: Database.Database,
   runId: string,
   subtaskId: string,
   inputJson: string,
   claimToken: string,
+  stmt: Database.Statement,
 ): NextWorkData | null {
-  void db;
-  void runId;
-  void subtaskId;
-  void inputJson;
-  void claimToken;
-  throw new Error("not implemented");
+  const def = readPipelineDef(runId, stmt);
+  if (def === null) return null;
+  const subtask = def.subtasks.find((s) => s.id === subtaskId);
+  if (
+    subtask === undefined ||
+    subtask.instructions === undefined ||
+    subtask.output_schema === undefined
+  ) {
+    return null;
+  }
+  let input: unknown = {};
+  try {
+    input = JSON.parse(inputJson);
+  } catch {
+    input = {};
+  }
+  return {
+    instructions: subtask.instructions,
+    input,
+    output_schema: subtask.output_schema,
+    claim: claimToken,
+  };
 }
 
-/**
- * Type-only re-export so consumers (and tests) can build envelope literals
- * without importing the contracts package twice.
- */
-export type AgentEnvelope<T> = EnvelopeResponse<T>;
-export type AgentOk<T> = Ok<T>;
-export type AgentErr = Err;

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,9 @@ import { Hono } from "hono";
 
 import type { Err } from "@murmur/contracts-types";
 
-import { bearerAuth } from "./auth/index.js";
+import { createAgentApp } from "./api/agent/index.js";
 import { createPublisherApp } from "./api/publisher/index.js";
+import { bearerAuth } from "./auth/index.js";
 
 /**
  * Options accepted by `createServer`.
@@ -24,16 +25,17 @@ export interface CreateServerOptions {
    */
   token: Buffer;
   /**
-   * Open SQLite handle. When supplied, the publisher sub-app
-   * (`src/api/publisher`) is mounted and serves `POST /pipelines`,
-   * `POST /pipelines/{id}/runs`, and `GET /runs/{run_id}`. When omitted,
-   * the publisher routes are absent and any request to those paths falls
-   * through to the 404 handler (e.g. tests that only exercise auth).
+   * Optional open `better-sqlite3` handle. When supplied, both the publisher
+   * sub-app (`src/api/publisher` — `POST /pipelines`, `POST /pipelines/{id}/runs`,
+   * `GET /runs/{run_id}`) and the agent sub-app (`src/api/agent` — `GET /work/next`,
+   * `POST /work/{claim_token}/result`) are mounted on top of the bearer-auth gate.
+   * Tests that only exercise auth/health may omit it; in that case both sub-apps
+   * are absent and any request to their paths falls through to the 404 handler.
    *
-   * The factory does NOT take ownership — callers are responsible for
-   * lifecycle. Migrations MUST have been run on the handle before
-   * `createServer` is called; the publisher sub-app assumes the schema
-   * is already in place.
+   * The factory does NOT take ownership — callers are responsible for the
+   * connection's lifecycle. Migrations MUST have been run on the handle
+   * before `createServer` is called; both sub-apps assume the schema is
+   * already in place.
    */
   db?: Database.Database;
 }
@@ -66,14 +68,13 @@ export function createServer(options: CreateServerOptions): Hono {
 
   app.get("/health", (c) => c.json({ ok: true }));
 
-  // Publisher sub-app: registered only when a DB handle was supplied.
-  // The sub-app exposes `POST /pipelines`, `POST /pipelines/{id}/runs`,
-  // and `GET /runs/{run_id}`. Mounted at `/` because each route owns
-  // its own absolute path; bearer-auth above the mount applies. See
-  // `src/api/publisher/index.ts`.
+  // Sub-apps: registered only when a DB handle was supplied. Both inherit the
+  // bearer-auth gate installed above. Publisher at `/` (each route owns its
+  // own absolute path); agent at `/work` (DESIGN.md §3.3).
   if (options.db !== undefined) {
     const publisher = createPublisherApp({ db: options.db });
     app.route("/", publisher);
+    app.route("/work", createAgentApp({ db: options.db }));
   }
 
   // 404 fallback. The body conforms to M0's `Err` envelope shape:


### PR DESCRIPTION
## Summary
Implements M5 (issue #10): the two atomic agent endpoints — `GET /work/next` and `POST /work/{claim_token}/result` — backed by SQLite `BEGIN IMMEDIATE` + `UPDATE … RETURNING`. All response envelopes follow the M0 contract (`{ ok, errors?, data? }`); no `accepted:` shape anywhere.

## Related issue
Closes colophon-group/murmur#10

## Files changed (high-level)
- `src/api/agent/sql.ts` — `CLAIM_SQL` and `CAS_SQL` (single-statement atomic UPDATE…RETURNING) plus `INSERT_RESULT_SQL` and `INSERT_AGENT_ACTION_SQL`. Each statement carries a clause-by-clause comment explaining why every predicate is load-bearing.
- `src/api/agent/work.ts` — Hono routes. `GET /next` wraps the claim SQL in `BEGIN IMMEDIATE`/`COMMIT`; `POST /:claim_token/result` validates against the subtask def's `output_schema` (via `validateAgainst` from M9), then runs the CAS + result + audit write in a single transaction. `notes` is persisted to `agent_actions` only, never to `subtask_results.notes` (DESIGN.md §3.1, last bullet).
- `src/api/agent/lifecycle.ts` — `markNextReady` promotes any `pending` instances whose `requires` are now satisfied. `spawnChildren` and `maybeFinaliseRun` are documented stubs for M8 / M10.
- `src/api/agent/index.ts` — sub-app factory.
- `src/server.ts` — accepts an optional `db` handle; mounts `/work` when one is supplied. Existing auth/health behaviour unchanged.
- `src/api/agent/agent.test.ts` — full vitest suite covering every Verification bullet.

## Verification (from issue #10)
- [x] `GET /work/next` on empty queue → `{ ok: true, data: null }` (HTTP 200, body present)
- [x] `GET /work/next` on populated queue → `{ ok: true, data: { instructions, input, output_schema, claim } }`
- [x] **Concurrency stress**: 50 concurrent calls vs a 10-row queue produce exactly 10 distinct claim tokens, 40 nulls, no duplicates
- [x] `POST /result` with unknown claim → `{ ok: false, errors: ["claim_lost"] }`
- [x] `POST /result` with expired claim (TTL elapsed) → `{ ok: false, errors: ["claim_lost"] }`
- [x] `POST /result` with schema-invalid output → `{ ok: false, errors: ["validation:/...:msg", ...] }` (row stays `claimed`, never flipped to `done`)
- [x] `POST /result` with valid output → `{ ok: true, data: { run_id } }`, status flipped to `done`, `claim_token` cleared
- [x] `notes` persisted to `agent_actions`, NOT to `subtask_results.notes`
- [x] After CAS, the next `GET /work/next` returns the next ready subtask (integration)
- [x] Idempotency: re-submitting against an already-done claim returns `claim_lost`
- [x] Envelope grep gate: `pnpm grep-no-accepted-key` empty
- [x] The atomic claim statement is in **one** `db.prepare(…).get(…)` call; CAS is also one statement; both have correctness comments

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ — 100 tests pass; coverage `src/api/**` 90.57% lines / 77.14% branches (gate 85% / 75%)
- `pnpm grep:all` ✓
- 50-concurrent stress test result: 10 distinct claims, 40 nulls, 0 duplicates (deterministic across runs)

## Notes for reviewer
- The issue body's atomic-claim SQL referenced `subtask_def_id` / `bind`; the M2 schema column names are `subtask_id` / `input_json`. I used the actual column names and called this out in the SQL comment in `sql.ts`.
- The CAS UPDATE clears `claim_token` to NULL on success so the partial unique index keeps allowing inserts and the row stops surfacing in subsequent claim queries.
- `expires_at > now` uses lexicographic ordering on RFC 3339 UTC strings — relies on canonical Z-suffixed millisecond format, which the route enforces via the shared `nowFn` seam (`Date.toISOString()` / test override).
- M8 (spawns, #16) and M10 (webhook, #18) are stubbed with TODOs referencing those issues — the demo's deterministic-DAG happy path is exercised end-to-end without them.
- The CAS-race branch (post-SELECT, pre-UPDATE) is unreachable under better-sqlite3's connection mutex; left in the handler as a safety net for the future multi-connection / multi-process case.