### PR TITLE
feat(mcp): MCP server with three static tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
     "migrate:memory": "tsx src/db/cli.ts --memory"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@murmur/contracts-types": "workspace:*",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.9.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@murmur/contracts-types':
         specifier: workspace:*
         version: link:packages/contracts-types
@@ -23,6 +26,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
@@ -429,6 +435,12 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -469,6 +481,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -742,6 +764,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -809,6 +835,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -826,9 +856,21 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -866,6 +908,26 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -898,12 +960,23 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -911,14 +984,30 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -929,6 +1018,9 @@ packages:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -988,6 +1080,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -995,6 +1099,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1026,6 +1140,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1041,6 +1159,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -1048,6 +1174,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -1072,6 +1209,10 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
@@ -1079,12 +1220,32 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   hono@4.6.12:
     resolution: {integrity: sha512-eHtf4kSDNw6VVrdbd5IQi16r22m3s7mWPLd7xOMhg1a/Yyb1A0qpUFq8xYMX4FMuDe1nTKeMX5rTx7Nmw+a+Ag==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1107,6 +1268,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -1125,6 +1294,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1148,6 +1320,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1166,6 +1341,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1211,6 +1389,18 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1218,6 +1408,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1263,9 +1461,25 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1293,6 +1507,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -1307,6 +1525,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1326,6 +1547,10 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1340,6 +1565,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1347,8 +1576,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1378,16 +1619,34 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1396,6 +1655,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1416,6 +1691,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -1484,6 +1763,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   true-myth@4.1.1:
     resolution: {integrity: sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==}
     engines: {node: 10.* || >= 12.*}
@@ -1513,6 +1796,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript-eslint@8.16.0:
     resolution: {integrity: sha512-wDkVmlY6O2do4V+lZd0GtRfbtXbeD0q9WygwXXSJnC1xorE8eqyC2L1tJimqpSeFrOzRlYtWnUp/uzgHQOgfBQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1531,11 +1818,19 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1635,6 +1930,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -1855,6 +2158,10 @@ snapshots:
     dependencies:
       hono: 4.6.12
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1895,6 +2202,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2147,6 +2476,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2206,6 +2540,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -2228,7 +2576,19 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -2261,6 +2621,19 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -2289,13 +2662,25 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2305,7 +2690,15 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2359,6 +2752,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2438,9 +2833,55 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -2472,6 +2913,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2489,10 +2941,34 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -2519,13 +2995,35 @@ snapshots:
 
   globals@14.0.0: {}
 
+  gopd@1.2.0: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.15: {}
+
   hono@4.6.12: {}
 
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2542,6 +3040,10 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-arrayish@0.2.1: {}
 
   is-extglob@2.1.1: {}
@@ -2553,6 +3055,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2583,6 +3087,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -2596,6 +3102,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2638,12 +3146,24 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-response@3.1.0: {}
 
@@ -2675,9 +3195,19 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2713,6 +3243,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parseurl@1.3.3: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -2724,6 +3256,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   path-type@4.0.0: {}
 
   pathe@1.1.2: {}
@@ -2733,6 +3267,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.12:
     dependencies:
@@ -2757,6 +3293,11 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -2764,7 +3305,20 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2818,19 +3372,86 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2847,6 +3468,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -2917,6 +3540,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   true-myth@4.1.1: {}
 
   ts-api-utils@1.4.3(typescript@5.6.3):
@@ -2952,6 +3577,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.16.0(eslint@9.15.0)(typescript@5.6.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0)(typescript@5.6.3))(eslint@9.15.0)(typescript@5.6.3)
@@ -2967,11 +3598,15 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite-node@2.1.9(@types/node@22.9.0):
     dependencies:
@@ -3065,3 +3700,9 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,512 @@
+/**
+ * Tests for `src/mcp/server.ts` and `src/mcp/tools.ts` — Murmur's MCP
+ * surface (DESIGN.md §3.4).
+ *
+ * Test layers:
+ *
+ *   1. **JSON-RPC behaviour** — exercised through the SDK's
+ *      `InMemoryTransport.createLinkedPair()` so `initialize`, `tools/list`,
+ *      and `tools/call` are tested end-to-end without going through HTTP.
+ *      Bearer auth is N/A on this transport; tool handlers see
+ *      `extra.requestInfo === undefined` and forward no Authorization
+ *      header — the wrapped agent app is constructed without the auth
+ *      middleware in this layer (tests pass the agent sub-app directly
+ *      from `createAgentApp`, which has no app-level auth).
+ *
+ *   2. **HTTP transport + bearer auth** — exercised through the full
+ *      `createServer({ token, db })` with the MCP route mounted under
+ *      `/mcp`. We assert that requests without/with-bad bearer tokens
+ *      fail at the parent app's auth middleware before ever reaching
+ *      the SDK transport.
+ *
+ *   3. **Reconnect** — close the in-memory client transport, build a
+ *      fresh client, and verify `initialize` succeeds again. (This is
+ *      the in-process analogue of the cloudflared idle-drop path; for
+ *      stateless mode any new request rebuilds the server.)
+ *
+ * Test bullets are taken verbatim from issue #11's "Verification"
+ * section. Every named bullet has at least one corresponding `it()`
+ * below; the bullet text is included in the test title so a reviewer
+ * can grep for it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type Database from "better-sqlite3";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+import { openDb } from "../db/index.js";
+import { runMigrations } from "../db/migrate.js";
+import { createAgentApp } from "../api/agent/index.js";
+import { createServer } from "../server.js";
+
+import {
+  PULL_TASK_DESCRIPTION,
+  SUBMIT_RESULT_DESCRIPTION,
+  TASK_TOOL_DESCRIPTION,
+  TOOL_PULL_TASK,
+  TOOL_SUBMIT_RESULT,
+  TOOL_TASK_TOOL,
+  registerMcpTools,
+} from "./tools.js";
+
+/* -------------------------------------------------------------------------- */
+/*  Shared fixtures                                                            */
+/* -------------------------------------------------------------------------- */
+
+const TEST_PIPELINE_ID = "test-pipeline";
+const TEST_PIPELINE_VERSION = 1;
+const TEST_PIPELINE_DEF = {
+  id: TEST_PIPELINE_ID,
+  subtasks: [
+    {
+      id: "first",
+      instructions: "Do the first thing.",
+      output_schema: {
+        type: "object",
+        properties: { score: { type: "integer" } },
+        required: ["score"],
+        additionalProperties: false,
+      },
+    },
+  ],
+};
+
+interface DbFixture {
+  readonly db: Database.Database;
+}
+
+function setupDb(): DbFixture {
+  const db = openDb(":memory:");
+  runMigrations(db);
+  const now = "2026-04-29T12:00:00.000Z";
+  db.prepare(
+    `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(
+    TEST_PIPELINE_ID,
+    TEST_PIPELINE_VERSION,
+    JSON.stringify(TEST_PIPELINE_DEF),
+    now,
+    now,
+  );
+  return { db };
+}
+
+function seedReadyRun(db: Database.Database, runId: string): void {
+  const now = "2026-04-29T12:00:00.000Z";
+  db.prepare(
+    `INSERT INTO runs
+       (id, pipeline_id, pipeline_version, status, initial_input_json,
+        webhook_url, created_at)
+     VALUES (?, ?, ?, 'running', '{}', 'https://example.test/webhook', ?)`,
+  ).run(runId, TEST_PIPELINE_ID, TEST_PIPELINE_VERSION, now);
+  db.prepare(
+    `INSERT INTO subtask_instances
+       (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+     VALUES (?, ?, ?, 'ready', '{}', ?, ?)`,
+  ).run(`${runId}-first`, runId, "first", now, now);
+}
+
+/**
+ * Build a fresh in-memory MCP client/server pair wired to a freshly
+ * seeded DB and agent app. Returns the connected client + a cleanup hook.
+ */
+async function makeInMemoryHarness(): Promise<{
+  client: Client;
+  db: Database.Database;
+  cleanup(): Promise<void>;
+}> {
+  const fixture = setupDb();
+  seedReadyRun(fixture.db, "run-A");
+
+  const agentApp = createAgentApp({ db: fixture.db });
+  const server = new McpServer({ name: "murmur-test", version: "0.0.0" });
+  registerMcpTools(server, { agentApp });
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client(
+    { name: "murmur-test-client", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    db: fixture.db,
+    async cleanup() {
+      await client.close();
+      await server.close();
+      fixture.db.close();
+    },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Layer 1 — JSON-RPC behaviour via the in-memory transport pair             */
+/* -------------------------------------------------------------------------- */
+
+describe("MCP server — initialize and tools/list", () => {
+  it("MCP `initialize` succeeds; `tools/list` returns exactly 3 tools with correct descriptions", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      // `initialize` ran inside `client.connect`; verify the server's
+      // capabilities surface includes `tools`.
+      const caps = h.client.getServerCapabilities();
+      expect(caps?.tools).toBeDefined();
+
+      const result = await h.client.listTools();
+      expect(result.tools).toHaveLength(3);
+
+      const byName = new Map(result.tools.map((t) => [t.name, t]));
+      expect(byName.get(TOOL_PULL_TASK)?.description).toBe(
+        PULL_TASK_DESCRIPTION,
+      );
+      expect(byName.get(TOOL_SUBMIT_RESULT)?.description).toBe(
+        SUBMIT_RESULT_DESCRIPTION,
+      );
+      expect(byName.get(TOOL_TASK_TOOL)?.description).toBe(
+        TASK_TOOL_DESCRIPTION,
+      );
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("Tool schemas: pull_task has no params; submit_result requires `claim` + `result`; task_tool requires `subcommand` + `claim`", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      const result = await h.client.listTools();
+      const byName = new Map(result.tools.map((t) => [t.name, t]));
+
+      // `pull_task` — no params. The SDK still emits an inputSchema
+      // object (JSON-Schema requires `type: 'object'`); what matters is
+      // that there are no required fields.
+      const pull = byName.get(TOOL_PULL_TASK);
+      expect(pull).toBeDefined();
+      const pullSchema = pull!.inputSchema as {
+        type: string;
+        properties?: Record<string, unknown>;
+        required?: string[];
+      };
+      expect(pullSchema.type).toBe("object");
+      expect(pullSchema.required ?? []).toEqual([]);
+
+      // `submit_result` — requires `claim` + `result`; `notes` optional.
+      const submit = byName.get(TOOL_SUBMIT_RESULT);
+      expect(submit).toBeDefined();
+      const submitSchema = submit!.inputSchema as {
+        type: string;
+        required?: string[];
+        properties: Record<string, unknown>;
+      };
+      expect(submitSchema.type).toBe("object");
+      expect(new Set(submitSchema.required ?? [])).toEqual(
+        new Set(["claim", "result"]),
+      );
+      expect(submitSchema.properties).toHaveProperty("notes");
+
+      // `task_tool` — requires `subcommand` + `claim`; `args` optional.
+      const taskTool = byName.get(TOOL_TASK_TOOL);
+      expect(taskTool).toBeDefined();
+      const taskToolSchema = taskTool!.inputSchema as {
+        type: string;
+        required?: string[];
+        properties: Record<string, unknown>;
+      };
+      expect(taskToolSchema.type).toBe("object");
+      expect(new Set(taskToolSchema.required ?? [])).toEqual(
+        new Set(["subcommand", "claim"]),
+      );
+      expect(taskToolSchema.properties).toHaveProperty("args");
+    } finally {
+      await h.cleanup();
+    }
+  });
+});
+
+describe("MCP server — pull_task delegates to /work/next", () => {
+  it("`pull_task` MCP call delegates to `/work/next` and returns the same shape (envelope intact)", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      const result = await h.client.callTool({ name: TOOL_PULL_TASK });
+      // The handler emits both a structuredContent (envelope) and a
+      // matching textual rendering. We assert against the structured
+      // form — that's the contract the host actually consumes.
+      const envelope = result.structuredContent as EnvelopeResponse<{
+        instructions: string;
+        input: unknown;
+        output_schema: Record<string, unknown>;
+        claim: string;
+      }>;
+      expect(envelope.ok).toBe(true);
+      if (!envelope.ok || envelope.data === undefined) {
+        throw new Error("expected populated data");
+      }
+      expect(envelope.data?.instructions).toBe("Do the first thing.");
+      expect(envelope.data?.claim.length).toBeGreaterThan(0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("`pull_task` on an empty queue returns `{ ok: true, data: null }`", async () => {
+    // Build a fresh harness with no seeded run.
+    const fixture = setupDb();
+    const agentApp = createAgentApp({ db: fixture.db });
+    const server = new McpServer({ name: "murmur-test", version: "0.0.0" });
+    registerMcpTools(server, { agentApp });
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client(
+      { name: "murmur-test-client", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.callTool({ name: TOOL_PULL_TASK });
+      const envelope = result.structuredContent as EnvelopeResponse<unknown>;
+      expect(envelope.ok).toBe(true);
+      if (!envelope.ok) throw new Error("unreachable");
+      expect(envelope.data).toBeNull();
+    } finally {
+      await client.close();
+      await server.close();
+      fixture.db.close();
+    }
+  });
+});
+
+describe("MCP server — submit_result delegates to /work/{claim}/result", () => {
+  it("`submit_result` MCP call delegates to `/work/{claim}/result` (envelope intact)", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      // First claim a task to obtain a claim token.
+      const pull = await h.client.callTool({ name: TOOL_PULL_TASK });
+      const pullEnv = pull.structuredContent as EnvelopeResponse<{
+        claim: string;
+      }>;
+      if (!pullEnv.ok || pullEnv.data === undefined || pullEnv.data === null) {
+        throw new Error("expected claim");
+      }
+      const claim = pullEnv.data.claim;
+
+      const result = await h.client.callTool({
+        name: TOOL_SUBMIT_RESULT,
+        arguments: {
+          claim,
+          result: { score: 7 },
+        },
+      });
+      const envelope = result.structuredContent as EnvelopeResponse<{
+        run_id: string;
+      }>;
+      expect(envelope.ok).toBe(true);
+      if (!envelope.ok || envelope.data === undefined) {
+        throw new Error("expected run_id");
+      }
+      expect(envelope.data?.run_id).toBe("run-A");
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("`submit_result` with an unknown claim returns `claim_lost` (envelope intact)", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      const result = await h.client.callTool({
+        name: TOOL_SUBMIT_RESULT,
+        arguments: {
+          claim: "c_does_not_exist",
+          result: { score: 7 },
+        },
+      });
+      const envelope = result.structuredContent as EnvelopeResponse<unknown>;
+      expect(envelope.ok).toBe(false);
+      if (envelope.ok) throw new Error("unreachable");
+      expect(envelope.errors).toContain("claim_lost");
+    } finally {
+      await h.cleanup();
+    }
+  });
+});
+
+describe("MCP server — task_tool stub (M7 stand-in)", () => {
+  it("`task_tool` returns `{ ok: false, errors: ['not_implemented'] }` until M7 lands", async () => {
+    const h = await makeInMemoryHarness();
+    try {
+      const result = await h.client.callTool({
+        name: TOOL_TASK_TOOL,
+        arguments: {
+          subcommand: "probe monitor",
+          claim: "c_irrelevant_for_stub",
+          args: { board_url: "https://example.test" },
+        },
+      });
+      const envelope = result.structuredContent as EnvelopeResponse<unknown>;
+      expect(envelope.ok).toBe(false);
+      if (envelope.ok) throw new Error("unreachable");
+      expect(envelope.errors).toEqual(["not_implemented"]);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Layer 2 — HTTP transport with bearer auth                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("MCP transport — bearer auth", () => {
+  const tokenStr = "test-token-7777";
+  const token = Buffer.from(tokenStr, "utf8");
+
+  /**
+   * A representative MCP `initialize` JSON-RPC envelope. We don't go
+   * through the SDK client here — the test is about the auth gate, not
+   * the transport. A literal POST body suffices and keeps the test
+   * deterministic.
+   */
+  function initBody(): string {
+    return JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.0" },
+      },
+    });
+  }
+
+  it("Bearer auth enforced on the MCP transport — missing header → 401", async () => {
+    const fixture = setupDb();
+    try {
+      const app = createServer({ token, db: fixture.db });
+      const response = await app.request("/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: initBody(),
+      });
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as EnvelopeResponse<unknown>;
+      expect(body.ok).toBe(false);
+      if (body.ok) throw new Error("unreachable");
+      expect(body.errors).toContain("unauthorized");
+    } finally {
+      fixture.db.close();
+    }
+  });
+
+  it("Bearer auth enforced on the MCP transport — wrong token → 401", async () => {
+    const fixture = setupDb();
+    try {
+      const app = createServer({ token, db: fixture.db });
+      const response = await app.request("/mcp", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer not-the-right-token",
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: initBody(),
+      });
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as EnvelopeResponse<unknown>;
+      expect(body.ok).toBe(false);
+    } finally {
+      fixture.db.close();
+    }
+  });
+
+  it("Bearer auth enforced on the MCP transport — same `MURMUR_TOKEN` admits an `initialize` request", async () => {
+    const fixture = setupDb();
+    try {
+      const app = createServer({ token, db: fixture.db });
+      const response = await app.request("/mcp", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${tokenStr}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: initBody(),
+      });
+      // The SDK responds 200 with an SSE/JSON body on a successful
+      // initialize. We don't parse the body — passing the auth gate is
+      // what this test asserts.
+      expect(response.status).toBe(200);
+    } finally {
+      fixture.db.close();
+    }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Layer 3 — reconnect after a forced disconnect                             */
+/* -------------------------------------------------------------------------- */
+
+describe("MCP transport — reconnect", () => {
+  it("Reconnect after a forced disconnect re-issues `initialize` cleanly", async () => {
+    const fixture = setupDb();
+    seedReadyRun(fixture.db, "run-A");
+    try {
+      const agentApp = createAgentApp({ db: fixture.db });
+
+      // First server + client pair.
+      const server1 = new McpServer({ name: "murmur-test", version: "0.0.0" });
+      registerMcpTools(server1, { agentApp });
+      const [c1, s1] = InMemoryTransport.createLinkedPair();
+      await server1.connect(s1);
+      const client1 = new Client(
+        { name: "murmur-test-client", version: "0.0.0" },
+        { capabilities: {} },
+      );
+      await client1.connect(c1);
+
+      // Verify the first session works.
+      const list1 = await client1.listTools();
+      expect(list1.tools).toHaveLength(3);
+
+      // Forced disconnect — close the client and the server.
+      await client1.close();
+      await server1.close();
+
+      // Build a fresh server + client (mirrors what the Hono /mcp route
+      // does on every request in stateless mode).
+      const server2 = new McpServer({ name: "murmur-test", version: "0.0.0" });
+      registerMcpTools(server2, { agentApp });
+      const [c2, s2] = InMemoryTransport.createLinkedPair();
+      await server2.connect(s2);
+      const client2 = new Client(
+        { name: "murmur-test-client", version: "0.0.0" },
+        { capabilities: {} },
+      );
+      // This is the "re-issues `initialize` cleanly" check — `connect`
+      // performs the initialize round-trip; it MUST succeed.
+      await client2.connect(c2);
+      const list2 = await client2.listTools();
+      expect(list2.tools).toHaveLength(3);
+
+      await client2.close();
+      await server2.close();
+    } finally {
+      fixture.db.close();
+    }
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -101,9 +101,10 @@ export function createMcpRoute(options: CreateMcpRouteOptions): Hono {
     const server = new McpServer(MCP_SERVER_INFO);
     registerMcpTools(server, { agentApp: options.agentApp });
 
-    const transport = new WebStandardStreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    });
+    // Stateless mode: omit `sessionIdGenerator` entirely so the SDK does
+    // not generate or validate session IDs. (We can't pass `undefined`
+    // explicitly under TS's `exactOptionalPropertyTypes`.)
+    const transport = new WebStandardStreamableHTTPServerTransport({});
 
     // Connect server → transport. Per the SDK's design the
     // `connect(...)` call attaches the server's onmessage handler to the

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,132 @@
+/**
+ * MCP route mount — Streamable HTTP transport over Hono (DESIGN.md §3.4).
+ *
+ * The MCP TS SDK ships a `WebStandardStreamableHTTPServerTransport` that
+ * accepts a Web-Standard `Request` and returns a Web-Standard `Response`.
+ * Hono's `c.req.raw` is exactly that, so we wire the transport behind a
+ * single `app.all('/', …)` handler. Bearer auth is enforced by the parent
+ * app's `app.use('*', bearerAuth(…))` (mounted in `src/server.ts`); this
+ * sub-app sees only authenticated requests.
+ *
+ * **Stateless mode.** We construct one fresh `McpServer` + transport per
+ * request (`sessionIdGenerator: undefined`). For Murmur this is the right
+ * choice:
+ *
+ *   - claims are bound to `claim_token`, not MCP session id (DESIGN.md
+ *     §3.3) — the agent already passes `claim` explicitly to
+ *     `task_tool` / `submit_result`, so we don't need session affinity;
+ *   - it sidesteps the SDK's session-tracking memory model when the
+ *     transport is exposed through Cloudflare Tunnel, which can rotate
+ *     edges mid-stream;
+ *   - reconnect is trivially handled — the next request rebuilds the
+ *     server and re-runs `initialize`.
+ *
+ * **Keepalive.** The SDK's Streamable HTTP transport handles the SSE
+ * keepalive heartbeat itself (per the 2025-03 spec); the underlying
+ * `text/event-stream` response keeps comments flowing even when the
+ * application has nothing to send. Murmur's deployment requirement of a
+ * 25s keepalive (DESIGN.md §3.6) is met by the SDK's default cadence —
+ * if that ever drifts we'd need to override it via the
+ * `WebStandardStreamableHTTPServerTransport`'s options, but for the demo
+ * the SDK's defaults are sufficient. Documented here so a future change
+ * to the SDK is a known-known.
+ *
+ * **In-process delegation.** The three tool handlers call into M5's
+ * `createAgentApp(...)` via `app.request(...)`. No extra HTTP socket;
+ * the bearer header is forwarded so the agent sub-app's own auth
+ * middleware re-validates as a defence-in-depth step.
+ *
+ * @see DESIGN.md §3.4 — MCP server (agent-facing)
+ * @see src/api/agent — the wrapped HTTP routes
+ * @see src/mcp/tools.ts — the tool registrations
+ */
+
+import { Hono } from "hono";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+
+import { registerMcpTools } from "./tools.js";
+
+/**
+ * Murmur server identity surfaced in the MCP `initialize` response.
+ *
+ * `name` is what the host displays in its tool catalog; `version` tracks
+ * the demo milestone. Bumped when the protocol surface changes.
+ */
+export const MCP_SERVER_INFO = {
+  name: "murmur",
+  version: "0.1.0",
+} as const;
+
+/**
+ * Options accepted by {@link createMcpRoute}.
+ */
+export interface CreateMcpRouteOptions {
+  /**
+   * The in-process agent Hono app (M5 — `src/api/agent`). Tool handlers
+   * call this via `app.request(...)`. The factory does NOT take ownership;
+   * callers are responsible for the underlying DB connection's lifecycle.
+   *
+   * Required: there is no MCP surface without the agent endpoints.
+   */
+  readonly agentApp: Hono;
+}
+
+/**
+ * Build the Hono sub-app exposing Murmur's MCP transport.
+ *
+ * The returned app has a single route — `app.all('/', …)` — that hands
+ * every method (POST / GET / DELETE) to a per-request stateless
+ * Streamable HTTP transport. Mount it under `/mcp` in `src/server.ts`:
+ *
+ * ```ts
+ * if (options.db !== undefined) {
+ *   const agent = createAgentApp({ db: options.db });
+ *   app.route('/work', agent);
+ *   app.route('/mcp', createMcpRoute({ agentApp: agent }));
+ * }
+ * ```
+ *
+ * The factory is pure (no env reads, no socket creation) so it can be
+ * exercised with `app.request('/mcp', …)` in unit tests.
+ */
+export function createMcpRoute(options: CreateMcpRouteOptions): Hono {
+  const app = new Hono();
+
+  app.all("/", async (c) => {
+    // Build a fresh server + transport for this request. Stateless mode:
+    // the SDK does not generate or validate session IDs, so reconnects
+    // are trivially handled by the next request rebuilding the pair.
+    const server = new McpServer(MCP_SERVER_INFO);
+    registerMcpTools(server, { agentApp: options.agentApp });
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    // Connect server → transport. Per the SDK's design the
+    // `connect(...)` call attaches the server's onmessage handler to the
+    // transport and is required before `handleRequest`.
+    await server.connect(transport);
+
+    // The SDK's `handleRequest` consumes the Web-Standard Request and
+    // returns a Web-Standard Response. Hono's `c.req.raw` is the same
+    // shape, so we hand it straight through.
+    const response = await transport.handleRequest(c.req.raw);
+
+    // Best-effort cleanup: in stateless mode the transport ties its
+    // lifetime to the response stream; closing the server here is a
+    // belt-and-braces step. We deliberately do NOT await this — the
+    // response body may still be streaming and `close()` is safe to
+    // schedule for after the body completes.
+    void server.close().catch(() => {
+      // Ignore — server.close() throws only if already closed, which
+      // is harmless here.
+    });
+
+    return response;
+  });
+
+  return app;
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,335 @@
+/**
+ * MCP tool registrations for Murmur's three static tools (DESIGN.md §3.4).
+ *
+ * The three tools are:
+ *
+ *   - `pull_task()` → wraps `GET /work/next` (DESIGN.md §3.3).
+ *   - `submit_result(claim, result, notes?)` → wraps `POST /work/{claim}/result`.
+ *   - `task_tool(subcommand, claim, args?)` → universal subcommand dispatcher.
+ *     Handled by M7 (#12); for M6 the tool is registered with its full schema
+ *     but its handler is a stub that returns the M0 envelope
+ *     `{ ok: false, errors: ['not_implemented'] }`. M7 will replace the
+ *     handler body — the registration itself, including the description and
+ *     input schema, is final.
+ *
+ * Static descriptions come verbatim from DESIGN.md §3.4 — the host's tool
+ * catalog displays them and the demo plan depends on the wording. Every
+ * change to a description here MUST round-trip through DESIGN.md.
+ *
+ * **Envelope discipline.** All tool handlers return MCP `CallToolResult`
+ * objects whose `structuredContent` is an `EnvelopeResponse<T>` (the M0
+ * shape `{ ok, errors?, data? }` from `@murmur/contracts-types`). There is
+ * no parallel `accepted: true` shape (grep-no-accepted-key:allow — prose).
+ *
+ * **Auth propagation.** Tool handlers receive the HTTP request's
+ * `Authorization` header from the MCP `RequestHandlerExtra.requestInfo`
+ * surface (the SDK's per-request auth path) and forward it to the
+ * in-process agent app via `app.request(..., { headers: ... })`. The
+ * caller (`createMcpRoute`) is responsible for ensuring the bearer-auth
+ * middleware has already validated the header before the request reaches
+ * this layer; the forwarded header lets the agent sub-app's own
+ * middleware re-validate as a defence-in-depth step.
+ *
+ * @see DESIGN.md §3.3 — agent endpoints (the wrapped HTTP routes)
+ * @see DESIGN.md §3.4 — MCP server surface (the static descriptions)
+ * @see docs/contracts.md §4 — envelope shape
+ */
+
+import type { Hono } from "hono";
+import { z } from "zod";
+
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+/* -------------------------------------------------------------------------- */
+/*  Static descriptions (DESIGN.md §3.4 — copy them verbatim)                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `pull_task` description (DESIGN.md §3.4 first bullet).
+ *
+ * The §3.4 prose for `pull_task` is bare — the bullet specifies only the
+ * shape, not a host-facing description. We use the canonical sentence from
+ * the §3.5 worked example and the design's "atomically claim the oldest
+ * unclaimed subtask" phrase from §3.3, joined into a single agent-readable
+ * sentence. Stable for the demo; do not change without a DESIGN.md update.
+ */
+export const PULL_TASK_DESCRIPTION =
+  "Atomically claim the oldest unclaimed subtask instance across all pipelines. Returns `{ instructions, input, output_schema, claim }` or `null` when the queue is empty. Use the returned `claim` for any subsequent `task_tool` and `submit_result` calls.";
+
+/**
+ * `submit_result` description (DESIGN.md §3.4 second bullet).
+ */
+export const SUBMIT_RESULT_DESCRIPTION =
+  "Submit a structured `result` for the given `claim`. The optional `notes` is a free-text reflection persisted in the audit log alongside the structured `result`. Returns `{ accepted: true }` or `{ accepted: false, errors: [...] }` with per-field validation errors; this MCP wrapper preserves the underlying HTTP envelope (grep-no-accepted-key:allow — prose).";
+
+/**
+ * `task_tool` description — verbatim from DESIGN.md §3.4 (the static
+ * description visible to the host's tool catalog).
+ */
+export const TASK_TOOL_DESCRIPTION =
+  "Invoke a subcommand for the current claim. The subtask `instructions` will tell you which subcommands to use and when; `task_tool('<name>', '<claim>', {...})` invokes one. The `claim` value is what `pull_task` returned in its `claim` field.";
+
+/* -------------------------------------------------------------------------- */
+/*  Tool name constants — exported so tests can address them by symbol        */
+/* -------------------------------------------------------------------------- */
+
+export const TOOL_PULL_TASK = "pull_task";
+export const TOOL_SUBMIT_RESULT = "submit_result";
+export const TOOL_TASK_TOOL = "task_tool";
+
+/* -------------------------------------------------------------------------- */
+/*  Tool input schemas (Zod, surfaces as JSON Schema in tools/list)           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `pull_task` takes no parameters. The SDK's `registerTool` accepts an
+ * `inputSchema` of `undefined` for zero-arg tools; we keep this exported so
+ * tests can assert "no params" explicitly.
+ */
+export const PULL_TASK_INPUT_SHAPE = undefined;
+
+/**
+ * `submit_result` requires `claim` and `result`; `notes` is optional.
+ *
+ * `result` is `unknown` because the actual schema is per-subtask
+ * (publishers declare it). We document it as a JSON-serialisable object;
+ * Zod `.passthrough()` accepts arbitrary nested shapes.
+ */
+export const SUBMIT_RESULT_INPUT_SHAPE = {
+  claim: z
+    .string()
+    .min(1)
+    .describe(
+      "The opaque claim token returned by `pull_task` for the subtask whose result you are submitting.",
+    ),
+  result: z
+    .unknown()
+    .describe(
+      "The structured result. Validated against the subtask's `output_schema`; per-field errors are returned in the response envelope on failure.",
+    ),
+  notes: z
+    .string()
+    .optional()
+    .describe(
+      "Optional free-text reflection persisted in the audit log alongside the structured `result` (DESIGN.md §3.1).",
+    ),
+} as const;
+
+/**
+ * `task_tool` requires `subcommand` and `claim`; `args` is optional.
+ *
+ * The schema is final for M6 — M7 (#12) only replaces the handler body.
+ */
+export const TASK_TOOL_INPUT_SHAPE = {
+  subcommand: z
+    .string()
+    .min(1)
+    .describe(
+      "The publisher-declared subcommand to invoke (e.g. `'probe monitor'`, `'select monitor'`). Names are scoped to the claim's subtask def; `task_tool('help')` lists valid names when subcommand resolution fails.",
+    ),
+  claim: z
+    .string()
+    .min(1)
+    .describe(
+      "The opaque claim token returned by `pull_task`. Required (no session-based fallback in MVP).",
+    ),
+  args: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe(
+      "Subcommand arguments, validated by Murmur against the subcommand's `input_schema` before being proxied to the publisher.",
+    ),
+} as const;
+
+/* -------------------------------------------------------------------------- */
+/*  Public surface                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Options for {@link registerMcpTools}.
+ */
+export interface RegisterMcpToolsOptions {
+  /**
+   * The in-process Hono app implementing `GET /work/next` and
+   * `POST /work/{claim}/result` (M5 — `src/api/agent`). Tool handlers
+   * call this via `agentApp.request(...)` rather than crossing the
+   * network — same node, same DB handle, no extra TLS / cloudflared hop.
+   */
+  readonly agentApp: Hono;
+}
+
+/**
+ * Register Murmur's three static MCP tools on the supplied server.
+ *
+ * @returns nothing; mutates the server's tool registry.
+ */
+export function registerMcpTools(
+  server: McpServer,
+  options: RegisterMcpToolsOptions,
+): void {
+  registerPullTask(server, options.agentApp);
+  registerSubmitResult(server, options.agentApp);
+  registerTaskTool(server);
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Internal: tool handlers                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Extract the bearer header from the MCP request handler's per-request
+ * extra. The SDK exposes the underlying HTTP request's headers via
+ * `extra.requestInfo.headers` when the transport is one of the HTTP
+ * variants. For the in-memory transport (used in tests that don't exercise
+ * auth) this is `undefined`, in which case we forward an empty header set
+ * — the agent sub-app's own bearer-auth middleware will short-circuit the
+ * request as unauthorised, and the test harness either avoids the agent
+ * app or wraps it without auth.
+ */
+function authHeaderFromExtra(
+  extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+): string | undefined {
+  const headers = extra.requestInfo?.headers;
+  if (headers === undefined) return undefined;
+  const value = headers["authorization"];
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && value.length > 0) return value[0];
+  return undefined;
+}
+
+/**
+ * Build a `CallToolResult` whose `structuredContent` is the supplied
+ * envelope. Also emits a textual rendering for hosts that ignore the
+ * structured slot (e.g. plain-text loggers) — the `text` field is the
+ * JSON-serialised envelope, byte-identical to what `structuredContent`
+ * carries. Setting `isError` reflects the envelope's `ok` discriminator.
+ */
+function envelopeResult(envelope: EnvelopeResponse<unknown>): CallToolResult {
+  const text = JSON.stringify(envelope);
+  return {
+    content: [{ type: "text", text }],
+    structuredContent: envelope as Record<string, unknown>,
+    isError: !envelope.ok,
+  };
+}
+
+/**
+ * Forward an in-process call to the agent app and return its parsed
+ * envelope. Body is `null` for GET and a JSON object for POST.
+ */
+async function callAgentApp(
+  agentApp: Hono,
+  method: "GET" | "POST",
+  path: string,
+  authorization: string | undefined,
+  body?: unknown,
+): Promise<EnvelopeResponse<unknown>> {
+  const headers: Record<string, string> = {};
+  if (authorization !== undefined) headers["authorization"] = authorization;
+  if (method === "POST") headers["content-type"] = "application/json";
+
+  const response = await agentApp.request(path, {
+    method,
+    headers,
+    body: method === "POST" ? JSON.stringify(body ?? {}) : undefined,
+  });
+
+  // The agent app always emits JSON. We swallow non-JSON / non-envelope
+  // bodies into a structured failure rather than letting them throw — this
+  // keeps the tool contract single-shape.
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch {
+    return { ok: false, errors: ["bad_response"] };
+  }
+
+  if (!isEnvelope(parsed)) {
+    return { ok: false, errors: ["bad_response"] };
+  }
+  return parsed;
+}
+
+/**
+ * Type-guard for the M0 envelope. Restricts the agent-app response to a
+ * shape we can safely surface to MCP without leaking arbitrary objects.
+ */
+function isEnvelope(value: unknown): value is EnvelopeResponse<unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const ok = (value as { ok?: unknown }).ok;
+  if (ok === true) return true;
+  if (ok === false) {
+    const errors = (value as { errors?: unknown }).errors;
+    return Array.isArray(errors);
+  }
+  return false;
+}
+
+/* ---------------------------- pull_task ---------------------------------- */
+
+function registerPullTask(server: McpServer, agentApp: Hono): void {
+  server.registerTool(
+    TOOL_PULL_TASK,
+    {
+      description: PULL_TASK_DESCRIPTION,
+      // No inputSchema: zero-argument tool.
+    },
+    async (_args, extra) => {
+      const auth = authHeaderFromExtra(extra);
+      const env = await callAgentApp(agentApp, "GET", "/work/next", auth);
+      return envelopeResult(env);
+    },
+  );
+}
+
+/* --------------------------- submit_result ------------------------------- */
+
+function registerSubmitResult(server: McpServer, agentApp: Hono): void {
+  server.registerTool(
+    TOOL_SUBMIT_RESULT,
+    {
+      description: SUBMIT_RESULT_DESCRIPTION,
+      inputSchema: SUBMIT_RESULT_INPUT_SHAPE,
+    },
+    async (args, extra) => {
+      const auth = authHeaderFromExtra(extra);
+      const path = `/work/${encodeURIComponent(args.claim)}/result`;
+      const body: { result: unknown; notes?: string } = { result: args.result };
+      if (args.notes !== undefined) body.notes = args.notes;
+      const env = await callAgentApp(agentApp, "POST", path, auth, body);
+      return envelopeResult(env);
+    },
+  );
+}
+
+/* ----------------------------- task_tool --------------------------------- */
+
+function registerTaskTool(server: McpServer): void {
+  server.registerTool(
+    TOOL_TASK_TOOL,
+    {
+      description: TASK_TOOL_DESCRIPTION,
+      inputSchema: TASK_TOOL_INPUT_SHAPE,
+    },
+    // TODO(#12, M7): replace this stub with the dispatch implementation.
+    // Until M7 lands the tool registers cleanly (so `tools/list` shape is
+    // stable from M6 onward) but every call returns the M0
+    // `not_implemented` envelope. The SDK still validates `args` against
+    // TASK_TOOL_INPUT_SHAPE before invoking the handler.
+    () => {
+      const env: EnvelopeResponse<never> = {
+        ok: false,
+        errors: ["not_implemented"],
+      };
+      return Promise.resolve(envelopeResult(env));
+    },
+  );
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -276,15 +276,19 @@ function isEnvelope(value: unknown): value is EnvelopeResponse<unknown> {
 /* ---------------------------- pull_task ---------------------------------- */
 
 function registerPullTask(server: McpServer, agentApp: Hono): void {
+  // Zero-argument tool: when `inputSchema` is omitted, the SDK's
+  // `ToolCallback<undefined>` signature is `(extra) => CallToolResult`
+  // (NOT `(args, extra)`). See @modelcontextprotocol/sdk's
+  // `BaseToolCallback` discriminating on `Args extends undefined`.
   server.registerTool(
     TOOL_PULL_TASK,
     {
       description: PULL_TASK_DESCRIPTION,
       // No inputSchema: zero-argument tool.
     },
-    async (_args, extra) => {
+    async (extra) => {
       const auth = authHeaderFromExtra(extra);
-      const env = await callAgentApp(agentApp, "GET", "/work/next", auth);
+      const env = await callAgentApp(agentApp, "GET", "/next", auth);
       return envelopeResult(env);
     },
   );
@@ -301,7 +305,11 @@ function registerSubmitResult(server: McpServer, agentApp: Hono): void {
     },
     async (args, extra) => {
       const auth = authHeaderFromExtra(extra);
-      const path = `/work/${encodeURIComponent(args.claim)}/result`;
+      // The agent sub-app handles `POST /:claim_token/result` at its
+      // root — `/work` is the parent-mount prefix. Calls via
+      // `app.request(...)` go straight to the sub-app, so we omit the
+      // `/work` prefix here.
+      const path = `/${encodeURIComponent(args.claim)}/result`;
       const body: { result: unknown; notes?: string } = { result: args.result };
       if (args.notes !== undefined) body.notes = args.notes;
       const env = await callAgentApp(agentApp, "POST", path, auth, body);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -21,14 +21,16 @@
  * shape `{ ok, errors?, data? }` from `@murmur/contracts-types`). There is
  * no parallel `accepted: true` shape (grep-no-accepted-key:allow — prose).
  *
- * **Auth propagation.** Tool handlers receive the HTTP request's
- * `Authorization` header from the MCP `RequestHandlerExtra.requestInfo`
- * surface (the SDK's per-request auth path) and forward it to the
- * in-process agent app via `app.request(..., { headers: ... })`. The
- * caller (`createMcpRoute`) is responsible for ensuring the bearer-auth
- * middleware has already validated the header before the request reaches
- * this layer; the forwarded header lets the agent sub-app's own
- * middleware re-validate as a defence-in-depth step.
+ * **Auth propagation.** The bearer-auth gate is enforced by the parent
+ * Hono app's `app.use('*', bearerAuth(...))` middleware (mounted in
+ * `src/server.ts`); by the time a request reaches an MCP tool handler
+ * the token is already validated. Tool handlers nonetheless forward the
+ * request's `Authorization` header to the in-process agent app via
+ * `app.request(..., { headers: ... })` — the agent sub-app currently
+ * has no app-level middleware of its own, so this forwarding is inert in
+ * the present layout, but it lets us add auth on the sub-app later (or
+ * exchange the in-process call for an out-of-process HTTP call) without
+ * a round of churn at the call sites.
  *
  * @see DESIGN.md §3.3 — agent endpoints (the wrapped HTTP routes)
  * @see DESIGN.md §3.4 — MCP server surface (the static descriptions)

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -90,13 +90,6 @@ export const TOOL_TASK_TOOL = "task_tool";
 /* -------------------------------------------------------------------------- */
 
 /**
- * `pull_task` takes no parameters. The SDK's `registerTool` accepts an
- * `inputSchema` of `undefined` for zero-arg tools; we keep this exported so
- * tests can assert "no params" explicitly.
- */
-export const PULL_TASK_INPUT_SHAPE = undefined;
-
-/**
  * `submit_result` requires `claim` and `result`; `notes` is optional.
  *
  * `result` is `unknown` because the actual schema is per-subtask
@@ -214,9 +207,14 @@ function authHeaderFromExtra(
  */
 function envelopeResult(envelope: EnvelopeResponse<unknown>): CallToolResult {
   const text = JSON.stringify(envelope);
+  // `structuredContent` is typed as `Record<string, unknown>` by the SDK.
+  // The envelope is structurally a JSON object — cast through `unknown` to
+  // bridge nominal differences (Ok/Err's readonly props vs. an open
+  // record) without weakening the source type.
+  const structured = envelope as unknown as Record<string, unknown>;
   return {
     content: [{ type: "text", text }],
-    structuredContent: envelope as Record<string, unknown>,
+    structuredContent: structured,
     isError: !envelope.ok,
   };
 }
@@ -236,11 +234,14 @@ async function callAgentApp(
   if (authorization !== undefined) headers["authorization"] = authorization;
   if (method === "POST") headers["content-type"] = "application/json";
 
-  const response = await agentApp.request(path, {
-    method,
-    headers,
-    body: method === "POST" ? JSON.stringify(body ?? {}) : undefined,
-  });
+  // Build the RequestInit progressively so we don't pass `body: undefined`
+  // — TS's `exactOptionalPropertyTypes` rejects `undefined` for
+  // `BodyInit`-typed slots even though `fetch` itself accepts it.
+  const init: RequestInit = { method, headers };
+  if (method === "POST") {
+    init.body = JSON.stringify(body ?? {});
+  }
+  const response = await agentApp.request(path, init);
 
   // The agent app always emits JSON. We swallow non-JSON / non-envelope
   // bodies into a structured failure rather than letting them throw — this

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import type { Err } from "@murmur/contracts-types";
 import { createAgentApp } from "./api/agent/index.js";
 import { createPublisherApp } from "./api/publisher/index.js";
 import { bearerAuth } from "./auth/index.js";
+import { createMcpRoute } from "./mcp/server.js";
 
 /**
  * Options accepted by `createServer`.
@@ -74,7 +75,15 @@ export function createServer(options: CreateServerOptions): Hono {
   if (options.db !== undefined) {
     const publisher = createPublisherApp({ db: options.db });
     app.route("/", publisher);
-    app.route("/work", createAgentApp({ db: options.db }));
+    // Construct the agent sub-app once and reuse it for both the HTTP
+    // mount (`/work`) and the MCP transport (`/mcp`) — the MCP tool
+    // handlers call this exact instance via `app.request(...)`,
+    // sidestepping the network entirely (DESIGN.md §3.4 mounts both
+    // surfaces on the same port; sharing the in-process app removes a
+    // hop and a TLS round-trip).
+    const agent = createAgentApp({ db: options.db });
+    app.route("/work", agent);
+    app.route("/mcp", createMcpRoute({ agentApp: agent }));
   }
 
   // 404 fallback. The body conforms to M0's `Err` envelope shape:


### PR DESCRIPTION
## Summary

Mounts the official MCP TS SDK (`@modelcontextprotocol/sdk`) over Streamable HTTP at `/mcp` on the same Hono app as the publisher and agent surfaces. Three static tools are registered with their DESIGN.md §3.4 descriptions and schemas: `pull_task` (no params), `submit_result` (`claim` + `result`, optional `notes`), and `task_tool` (`subcommand` + `claim`, optional `args`). `pull_task` and `submit_result` delegate in-process to M5's `createAgentApp` via `app.request(...)`. `task_tool` is registered with its full schema but its handler is a stub returning `{ ok: false, errors: ['not_implemented'] }` until M7 (#12) replaces the body.

## Related issue

Closes colophon-group/murmur#11

## Files changed (high-level)

- `src/mcp/tools.ts` — three tool registrations with §3.4 descriptions, Zod input schemas, in-process agent-app handlers; M0 envelope discipline throughout
- `src/mcp/server.ts` — `createMcpRoute({ agentApp })`: builds an `McpServer` + `WebStandardStreamableHTTPServerTransport` per request (stateless mode), returns a Hono sub-app
- `src/mcp/server.test.ts` — vitest covering every issue-#11 verification bullet
- `src/server.ts` — mount the MCP sub-app at `/mcp` when `db` is supplied; share the agent-app instance between `/work` and the MCP handlers
- `package.json` / `pnpm-lock.yaml` — `@modelcontextprotocol/sdk@^1.29.0` + `zod@^4.x` to dependencies

## Verification (from the issue)

- [x] MCP `initialize` succeeds; `tools/list` returns exactly 3 tools with the correct descriptions
- [x] `pull_task` MCP call delegates to `/work/next` and returns the same shape (envelope intact)
- [x] `submit_result` MCP call delegates to `/work/{claim}/result` (envelope intact)
- [x] Tool schemas match: `pull_task` no params; `submit_result` requires `claim` + `result`; `task_tool` requires `subcommand` + `claim`
- [x] Bearer auth enforced on the MCP transport (per-request `Authorization: Bearer …`)
- [x] Reconnect after a forced disconnect re-issues `initialize` cleanly
- [x] Same `MURMUR_TOKEN` used as on the HTTP API
- [x] M0 grep gate `pnpm grep-no-accepted-key` passes
- [x] `task_tool` returns `{ ok: false, errors: ['not_implemented'] }` (M7 stub)

Streamable HTTP keepalive: the SDK's transport handles the SSE heartbeat per the 2025-03 spec — see the discussion docblock in `src/mcp/server.ts`. Note for reviewer.

## Manual checks run locally

- `pnpm typecheck` ok
- `pnpm lint` ok
- `pnpm test` ok (165 tests pass; 11 of them in `src/mcp/server.test.ts`)
- `pnpm grep:all` ok
- `pnpm build` ok

## Notes for reviewer

- **Stateless transport.** Per-request `McpServer` + transport pair (`sessionIdGenerator` omitted). Claims are bound to `claim_token`, not MCP session id (DESIGN.md §3.3), so session affinity is unnecessary, and stateless mode matches Cloudflare Tunnel's edge-rotation behaviour. Reconnect is "the next request rebuilds the pair."
- **In-process delegation.** Tool handlers call into M5's agent app via `app.request(...)` rather than crossing TLS to localhost. The agent app's routes are at `/next` and `/:claim_token/result` (the `/work` prefix is the parent-mount); the tool handlers therefore use those root-relative paths. See the comment block above each handler.
- **Bearer auth.** Verified at the parent `app.use('*', bearerAuth(token))` — three layer-2 tests post raw `initialize` JSON-RPC bodies through the full `createServer` pipeline to confirm missing/wrong tokens 401 and the correct token admits the request.
- **`PULL_TASK_DESCRIPTION`.** §3.4's bullet for `pull_task` doesn't supply a host-readable description (only `submit_result` and `task_tool` do). I synthesised the sentence from §3.3's "atomically claim the oldest unclaimed subtask" prose joined with §3.5's worked-example wording. Stable for the demo; flagged here so a reviewer can challenge the wording before it ships to a host's tool catalog.
- **`task_tool` stub.** The TODO comment references issue #12 (M7). The schema and description are final — only the handler body changes when M7 lands.