### PR TITLE
feat(api): spawns runtime — instantiate child subtasks atomically

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -60,6 +60,7 @@ subtasks:                           # required, ≥1
     spawns:                         # optional; for dynamic instantiation
       for_each: <field-on-output>
       template: <subtask-id>
+      bind_as: <input-key>          # optional; child sees { [bind_as]: element }
     requires: [<subtask-id>, ...]   # optional; explicit DAG edges
     skip_if: { ... }                # optional; JSONLogic-style — DEFERRED for MVP
 final_output:

--- a/docs/contracts/pipeline-def.schema.json
+++ b/docs/contracts/pipeline-def.schema.json
@@ -118,6 +118,12 @@
         "template": {
           "type": "string",
           "description": "Subtask id used as the template for each child."
+        },
+        "bind_as": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "description": "Optional input-key name under which the child sees the for_each element. The spawned subtask's input becomes { [bind_as]: <element> }. Omitted ⇒ the child sees the element verbatim."
         }
       }
     },

--- a/packages/contracts-types/src/pipeline.ts
+++ b/packages/contracts-types/src/pipeline.ts
@@ -48,6 +48,13 @@ export interface SpawnsDef {
   readonly for_each: string;
   /** Subtask def id used as the template for each child instance. */
   readonly template: string;
+  /**
+   * Optional input-key name under which the child sees the for_each
+   * element. Per DESIGN.md §3.1's worked example (`bind_as: board`), the
+   * spawned subtask's `pull_task` input becomes `{ [bind_as]: <element> }`.
+   * Omitted ⇒ the child's input is the element itself (legacy shape).
+   */
+  readonly bind_as?: string;
 }
 
 export interface SubtaskDef {

--- a/src/api/agent/lifecycle.ts
+++ b/src/api/agent/lifecycle.ts
@@ -2,29 +2,34 @@
  * Lifecycle helpers for the agent endpoints — runs after a successful
  * submit to advance the pipeline state.
  *
- * For M5 (this PR), the responsibilities are:
+ * Responsibilities:
  *
  *   - **Mark next-ready set** — flip any `pending` subtask_instances on the
- *     same run whose `requires` are now satisfied to `ready`. This is the
- *     deterministic-DAG path; spawn-driven instantiation is M8 territory.
+ *     same run whose `requires` are now satisfied to `ready` (M5).
  *
- * Stubs (not implemented in this PR — referenced for grep-trail):
+ *   - **Spawns** (M8 / issue #13). When the just-completed subtask declares
+ *     `spawns: { for_each, template, bind_as? }`, instantiate one child
+ *     instance per element of the parent's `output[for_each]` array. The
+ *     real work lives in `src/api/agent/spawns.ts`; this module wires it
+ *     into the post-CAS lifecycle.
  *
- *   - **Spawns** (M8 / issue #16). When the just-completed subtask declares
- *     `spawns: { for_each, template }`, instantiate one child instance per
- *     element of the parent's `output[for_each]` array. M5 leaves a TODO
- *     and returns without spawning.
- *
- *   - **Run-completion webhook** (M10 / issue #18). When all of a run's
- *     non-skipped subtasks reach `done`, compose `final_output` per the
- *     pipeline def's `composes:` rules and POST the run to `webhook_url`.
- *     M5 leaves a TODO; the run will sit in `running` until M10 ships.
+ *   - **Run-completion flip** — when every `subtask_instances` row of a
+ *     run is in a terminal state (`done`, `skipped`, or `failed`) and no
+ *     more spawns can fire, flip the run to `status='completed'` and set
+ *     `completed_at`. Webhook delivery and `final_output` composition
+ *     (M10 / M11) remain TODOs; flipping the row to `completed` is the
+ *     deterministic precondition both depend on.
  *
  * @see DESIGN.md §3.1 — `requires`, `spawns`, `composes`
  * @see DESIGN.md §3.3 — claim/CAS lifecycle
+ * @see src/api/agent/spawns.ts — spawn-row insertion
  */
 
 import type Database from "better-sqlite3";
+
+import type { SubtaskDef } from "@murmur/contracts-types";
+
+import { applySpawns } from "./spawns.js";
 
 /**
  * Promote any `pending` subtask_instances on `runId` whose `requires`
@@ -119,34 +124,65 @@ interface PipelineDefForLifecycle {
 }
 
 /**
- * M8 stub — spawn child instances when the just-completed subtask declares
- * `spawns:`. NOT implemented in this PR. See issue #16.
+ * Spawn child `subtask_instances` rows when the just-completed parent's
+ * subtask def declares a `spawns:` block (DESIGN.md §3.1, M8).
  *
- * The function is exported (rather than left as a comment) so the import
- * graph stays stable when M8 lands and so a grep for `spawnChildren` finds
- * the documented stub.
+ * Look up the parent's run id and subtask id from `subtask_instances`,
+ * read the run's pipeline def from `pipelines.def_json`, find the
+ * matching `SubtaskDef`, and delegate to {@link applySpawns}. Returns
+ * the spawned ids in insertion order; an empty result means the parent
+ * had no `spawns` directive, the for_each field was missing, or the
+ * for_each array was empty (issue's edge cases).
+ *
+ * Inserts run on the caller-supplied transaction. The caller (the CAS
+ * submit handler in `src/api/agent/work.ts`) wraps this call in a
+ * `BEGIN IMMEDIATE` so a thrown error rolls back any partial spawn
+ * inserts atomically with the CAS.
+ *
+ * @param db an open better-sqlite3 connection (already inside a txn).
+ * @param parentInstanceId the just-completed parent's instance id.
+ * @param output the parent's submitted, schema-validated result.
+ * @param now an RFC 3339 UTC string (used for child `created_at` /
+ *   `updated_at`).
+ * @param mintInstanceId function called once per spawned row.
+ * @returns the spawned child instance ids in insertion order.
  */
 export function spawnChildren(
   db: Database.Database,
   parentInstanceId: string,
   output: unknown,
   now: string,
+  mintInstanceId: () => string,
 ): ReadonlyArray<string> {
   void db;
   void parentInstanceId;
   void output;
   void now;
-  // TODO(M8 / colophon-group/murmur#16): instantiate one child per
-  // `output[spawns.for_each]` element, using the `spawns.template` subtask
-  // def. For M5 this is a no-op so the deterministic happy path runs.
-  return [];
+  void mintInstanceId;
+  throw new Error("not implemented");
 }
 
 /**
- * M10 stub — fire the run-completion webhook when all subtasks reach
- * `done`. NOT implemented in this PR. See issue #18.
+ * Flip the run to `completed` when every `subtask_instances` row is in a
+ * terminal state (`done`, `skipped`, or `failed`) AND there are no
+ * `pending`, `ready`, or `claimed` rows left that could still spawn or
+ * advance.
  *
- * Same export-rather-than-comment rationale as `spawnChildren`.
+ * Idempotent: a second call after the row is already `completed` is a
+ * no-op and returns `false`. Composing `final_output` and POSTing the
+ * webhook are deferred to M11 / M10 respectively (issue #18); the row
+ * flip is the deterministic precondition both depend on.
+ *
+ * Inserts run on the caller-supplied transaction. The caller wraps this
+ * in the same `BEGIN IMMEDIATE` as the parent CAS submit so the run
+ * status flip is atomic with the parent's submit.
+ *
+ * @param db an open better-sqlite3 connection (already inside a txn).
+ * @param runId the run to consider.
+ * @param now an RFC 3339 UTC string used for `completed_at`.
+ * @returns `true` if the run was flipped to `completed` by this call,
+ *   `false` otherwise (still running, already completed, or any other
+ *   terminal status).
  */
 export function maybeFinaliseRun(
   db: Database.Database,
@@ -156,9 +192,65 @@ export function maybeFinaliseRun(
   void db;
   void runId;
   void now;
-  // TODO(M10 / colophon-group/murmur#18): when all non-skipped instances
-  // of `runId` are `done`, compose `final_output` per the pipeline def's
-  // `composes:` and POST it to `webhook_url`. For M5 this is a no-op and
-  // the run stays in `status='running'`.
-  return false;
+  throw new Error("not implemented");
+}
+
+/**
+ * Helper: read the parent instance row's `(run_id, subtask_id)` so the
+ * caller can locate the parent's `SubtaskDef` in the pipeline def.
+ *
+ * Returns `null` if the row no longer exists (would indicate a logic
+ * error — the CAS just succeeded on this id).
+ *
+ * Exported so unit tests can probe the lookup independently of
+ * {@link spawnChildren}.
+ */
+export function lookupParentForSpawn(
+  db: Database.Database,
+  parentInstanceId: string,
+): { run_id: string; subtask_id: string } | null {
+  const row = db
+    .prepare(
+      `SELECT run_id, subtask_id FROM subtask_instances WHERE id = ?`,
+    )
+    .get(parentInstanceId) as
+    | { run_id: string; subtask_id: string }
+    | undefined;
+  if (row === undefined) return null;
+  return { run_id: row.run_id, subtask_id: row.subtask_id };
+}
+
+/**
+ * Helper: locate the parent's `SubtaskDef` inside the run's pipeline
+ * `def_json`. Used by {@link spawnChildren} to access `spawns:` and the
+ * template's full def.
+ *
+ * Exported so unit tests can probe the lookup independently of
+ * {@link spawnChildren}.
+ *
+ * @returns the matching `SubtaskDef` or `null` if either the pipeline
+ *   def cannot be located/parsed or the subtask def is missing.
+ */
+export function lookupSubtaskDef(
+  db: Database.Database,
+  runId: string,
+  subtaskId: string,
+): SubtaskDef | null {
+  const row = db
+    .prepare(
+      `SELECT pipelines.def_json AS def_json
+         FROM pipelines
+         JOIN runs ON runs.pipeline_id = pipelines.id
+        WHERE runs.id = ?`,
+    )
+    .get(runId) as { def_json: string } | undefined;
+  if (row === undefined) return null;
+  let def: { subtasks: ReadonlyArray<SubtaskDef> };
+  try {
+    def = JSON.parse(row.def_json) as { subtasks: ReadonlyArray<SubtaskDef> };
+  } catch {
+    return null;
+  }
+  const subtask = def.subtasks.find((s) => s.id === subtaskId);
+  return subtask ?? null;
 }

--- a/src/api/agent/lifecycle.ts
+++ b/src/api/agent/lifecycle.ts
@@ -154,12 +154,25 @@ export function spawnChildren(
   now: string,
   mintInstanceId: () => string,
 ): ReadonlyArray<string> {
-  void db;
-  void parentInstanceId;
-  void output;
-  void now;
-  void mintInstanceId;
-  throw new Error("not implemented");
+  const parent = lookupParentForSpawn(db, parentInstanceId);
+  if (parent === null) return [];
+
+  const subtaskDef = lookupSubtaskDef(db, parent.run_id, parent.subtask_id);
+  if (subtaskDef === null) return [];
+
+  // Delegate the actual INSERTs. `applySpawns` is a pure-against-the-db
+  // helper: it does not open a transaction, and a thrown SQLite error
+  // (e.g., FK violation) propagates up so the caller's BEGIN IMMEDIATE
+  // can ROLLBACK atomically with the parent's CAS.
+  return applySpawns(
+    db,
+    parentInstanceId,
+    parent.run_id,
+    subtaskDef,
+    output,
+    now,
+    mintInstanceId,
+  );
 }
 
 /**
@@ -189,10 +202,42 @@ export function maybeFinaliseRun(
   runId: string,
   now: string,
 ): boolean {
-  void db;
-  void runId;
-  void now;
-  throw new Error("not implemented");
+  // 1. Bail out if the run is already terminal. The flip is idempotent
+  //    but we want to avoid clobbering `completed_at`.
+  const runRow = db
+    .prepare(`SELECT status FROM runs WHERE id = ?`)
+    .get(runId) as { status: string } | undefined;
+  if (runRow === undefined) return false;
+  if (runRow.status !== "running") return false;
+
+  // 2. Count non-terminal instances. Terminal states are `done`,
+  //    `skipped`, `failed`. Anything else (`pending`, `ready`,
+  //    `claimed`, plus any future status) keeps the run live.
+  const nonTerminal = db
+    .prepare(
+      `SELECT COUNT(*) AS c FROM subtask_instances
+        WHERE run_id = ?
+          AND status NOT IN ('done', 'skipped', 'failed')`,
+    )
+    .get(runId) as { c: number };
+  if (nonTerminal.c > 0) return false;
+
+  // 3. Sanity: the run must have at least one row (otherwise the
+  //    publisher created the run with no subtasks — a bug, not a
+  //    completion). Avoids flipping an empty-shell run to `completed`.
+  const total = db
+    .prepare(`SELECT COUNT(*) AS c FROM subtask_instances WHERE run_id = ?`)
+    .get(runId) as { c: number };
+  if (total.c === 0) return false;
+
+  // 4. Flip. TODO(M11 / colophon-group/murmur#19): compose
+  //    `final_output` per `final_output.composes`. TODO(M10 /
+  //    colophon-group/murmur#18): POST the webhook. Both depend on the
+  //    row being `completed`; this is the precondition.
+  db.prepare(
+    `UPDATE runs SET status = 'completed', completed_at = ? WHERE id = ?`,
+  ).run(now, runId);
+  return true;
 }
 
 /**

--- a/src/api/agent/spawns.test.ts
+++ b/src/api/agent/spawns.test.ts
@@ -1,0 +1,868 @@
+/**
+ * Tests for `src/api/agent/spawns.ts` and the spawn wiring through
+ * `src/api/agent/lifecycle.ts` + `src/api/agent/work.ts` (DESIGN.md §3.1,
+ * issue #13 / M8).
+ *
+ * Test bullets are taken verbatim from issue #13's "Verification" section.
+ * Every named bullet has at least one corresponding `it()` below; the
+ * bullet text is included in the test title so a reviewer can grep for it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type Database from "better-sqlite3";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+import { openDb } from "../../db/index.js";
+import { runMigrations } from "../../db/migrate.js";
+
+import { createAgentApp } from "./index.js";
+import {
+  applySpawns,
+  bindChildInput,
+  extractForEachArray,
+} from "./spawns.js";
+import type { NextWorkData, SubmitOkData } from "./work.js";
+
+/**
+ * Pipeline def used by spawn tests. `list-boards` declares
+ * `spawns: { for_each, template, bind_as }`; `configure-board` is the
+ * spawn template. Schemas are deliberately permissive but require the
+ * spawn-relevant fields (so a malformed parent submit can't pass).
+ */
+const SPAWN_PIPELINE_ID = "spawn-pipeline";
+const SPAWN_PIPELINE_VERSION = 1;
+
+const SPAWN_PIPELINE_DEF = {
+  id: SPAWN_PIPELINE_ID,
+  initial_input: { type: "object" },
+  subtasks: [
+    {
+      id: "list-boards",
+      instructions: "List the company's boards.",
+      output_schema: {
+        type: "object",
+        properties: {
+          boards: { type: "array" },
+        },
+        required: ["boards"],
+        additionalProperties: false,
+      },
+      spawns: {
+        for_each: "boards",
+        template: "configure-board",
+        bind_as: "board",
+      },
+    },
+    {
+      id: "configure-board",
+      instructions: "Configure this board.",
+      output_schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
+        additionalProperties: false,
+      },
+    },
+  ],
+  final_output: {
+    composes: ["list-boards.*"],
+    webhook: "https://example.test/webhook",
+  },
+};
+
+/**
+ * Pipeline def for the "no spawn directive" path. Two subtasks, one
+ * `requires` the other, no `spawns:`.
+ */
+const NO_SPAWN_PIPELINE_ID = "no-spawn-pipeline";
+const NO_SPAWN_PIPELINE_DEF = {
+  id: NO_SPAWN_PIPELINE_ID,
+  initial_input: { type: "object" },
+  subtasks: [
+    {
+      id: "first",
+      instructions: "Do the first thing.",
+      output_schema: {
+        type: "object",
+        properties: { score: { type: "integer" } },
+        required: ["score"],
+        additionalProperties: false,
+      },
+    },
+    {
+      id: "second",
+      instructions: "Do the second thing, after first.",
+      output_schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
+        additionalProperties: false,
+      },
+      requires: ["first"],
+    },
+  ],
+  final_output: {
+    composes: ["first.*"],
+    webhook: "https://example.test/webhook",
+  },
+};
+
+/* ---------- Harness ---------- */
+
+interface SpawnHarness {
+  readonly db: Database.Database;
+  readonly app: ReturnType<typeof createAgentApp>;
+  readonly nowFn: () => string;
+  /** Counter for deterministic claim tokens. */
+  setNow(iso: string): void;
+}
+
+/**
+ * Build a fresh in-memory test harness, seed both pipelines, and return
+ * a Hono app whose `/work/next` and `/work/{token}/result` routes are
+ * mounted.
+ */
+function makeHarness(opts?: {
+  initialNow?: string;
+  pipelineDef?: typeof SPAWN_PIPELINE_DEF;
+  pipelineId?: string;
+  /** Force `instanceIdFn` to a deterministic counter for spawn ids. */
+  instanceIdSeed?: string;
+}): SpawnHarness {
+  const db = openDb(":memory:");
+  runMigrations(db);
+
+  const now = { value: opts?.initialNow ?? "2026-04-29T12:00:00.000Z" };
+  const nowFn = (): string => now.value;
+
+  // Seed both pipelines so each test can choose which to drive.
+  for (const [id, def] of [
+    [SPAWN_PIPELINE_ID, SPAWN_PIPELINE_DEF],
+    [NO_SPAWN_PIPELINE_ID, NO_SPAWN_PIPELINE_DEF],
+  ] as const) {
+    db.prepare(
+      `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(id, SPAWN_PIPELINE_VERSION, JSON.stringify(def), now.value, now.value);
+  }
+
+  let claimCounter = 0;
+  const claimTokenFn = (): string => {
+    claimCounter += 1;
+    return `c_${claimCounter.toString().padStart(8, "0")}`;
+  };
+
+  let instCounter = 0;
+  const instanceIdFn = (): string => {
+    instCounter += 1;
+    return `${opts?.instanceIdSeed ?? "spawn"}_${instCounter
+      .toString()
+      .padStart(4, "0")}`;
+  };
+
+  const app = createAgentApp({
+    db,
+    nowFn,
+    claimTokenFn,
+    instanceIdFn,
+  });
+
+  return {
+    db,
+    app,
+    nowFn,
+    setNow(iso: string): void {
+      now.value = iso;
+    },
+  };
+}
+
+/**
+ * Insert a `runs` row and one parent `subtask_instances` row in `ready`.
+ * The parent's input is `{}` — tests don't drive `inputs:` resolution
+ * here. Returns the parent instance id.
+ */
+function seedRunWithParent(
+  db: Database.Database,
+  runId: string,
+  pipelineId: string,
+  parentSubtaskId: string,
+  parentInstanceId: string,
+  now: string,
+): void {
+  db.prepare(
+    `INSERT INTO runs
+       (id, pipeline_id, pipeline_version, status, initial_input_json,
+        webhook_url, created_at)
+     VALUES (?, ?, ?, 'running', '{}', 'https://example.test/webhook', ?)`,
+  ).run(runId, pipelineId, SPAWN_PIPELINE_VERSION, now);
+  db.prepare(
+    `INSERT INTO subtask_instances
+       (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+     VALUES (?, ?, ?, 'ready', '{}', ?, ?)`,
+  ).run(parentInstanceId, runId, parentSubtaskId, now, now);
+}
+
+async function getJson<T>(
+  app: ReturnType<typeof createAgentApp>,
+  path: string,
+): Promise<{ status: number; body: EnvelopeResponse<T> }> {
+  const response = await app.request(path, { method: "GET" });
+  const body = (await response.json()) as EnvelopeResponse<T>;
+  return { status: response.status, body };
+}
+
+async function postJson<T>(
+  app: ReturnType<typeof createAgentApp>,
+  path: string,
+  body: unknown,
+): Promise<{ status: number; body: EnvelopeResponse<T> }> {
+  const response = await app.request(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const parsed = (await response.json()) as EnvelopeResponse<T>;
+  return { status: response.status, body: parsed };
+}
+
+/* ---------- Pure helpers ---------- */
+
+describe("extractForEachArray", () => {
+  it("returns the array for a present field", () => {
+    expect(extractForEachArray({ boards: ["a", "b"] }, "boards")).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("returns empty array for an empty for_each field (no spawn fires path keeps shape)", () => {
+    expect(extractForEachArray({ boards: [] }, "boards")).toEqual([]);
+  });
+
+  it("returns null when the field is missing", () => {
+    expect(extractForEachArray({ other: 1 }, "boards")).toBeNull();
+  });
+
+  it("returns null when the field is not an array", () => {
+    expect(extractForEachArray({ boards: "nope" }, "boards")).toBeNull();
+  });
+
+  it("returns null when the output is not an object", () => {
+    expect(extractForEachArray(null, "boards")).toBeNull();
+    expect(extractForEachArray(["x"], "boards")).toBeNull();
+    expect(extractForEachArray("x", "boards")).toBeNull();
+  });
+});
+
+describe("bindChildInput", () => {
+  it("wraps the element under `bind_as` when set", () => {
+    expect(
+      bindChildInput(
+        { for_each: "boards", template: "x", bind_as: "board" },
+        { alias: "careers-de" },
+      ),
+    ).toEqual({ board: { alias: "careers-de" } });
+  });
+
+  it("returns the element verbatim when bind_as is omitted", () => {
+    expect(
+      bindChildInput(
+        { for_each: "boards", template: "x" },
+        { alias: "careers-de" },
+      ),
+    ).toEqual({ alias: "careers-de" });
+  });
+});
+
+/* ---------- applySpawns (unit-level) ---------- */
+
+describe("applySpawns", () => {
+  it("inserts one row per element with bind_as wrapping", () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      let i = 0;
+      const ids = applySpawns(
+        h.db,
+        "p_parent",
+        "run-A",
+        SPAWN_PIPELINE_DEF.subtasks[0],
+        { boards: [{ alias: "a" }, { alias: "b" }, { alias: "c" }] },
+        h.nowFn(),
+        () => {
+          i += 1;
+          return `child_${i}`;
+        },
+      );
+      expect(ids).toEqual(["child_1", "child_2", "child_3"]);
+
+      const rows = h.db
+        .prepare(
+          `SELECT id, run_id, subtask_id, parent_instance_id, spawn_index,
+                  status, input_json
+             FROM subtask_instances
+            WHERE parent_instance_id = ?
+            ORDER BY spawn_index`,
+        )
+        .all("p_parent") as ReadonlyArray<{
+        id: string;
+        run_id: string;
+        subtask_id: string;
+        parent_instance_id: string;
+        spawn_index: number;
+        status: string;
+        input_json: string;
+      }>;
+      expect(rows.length).toBe(3);
+      expect(rows.map((r) => r.id)).toEqual(["child_1", "child_2", "child_3"]);
+      expect(rows.every((r) => r.run_id === "run-A")).toBe(true);
+      expect(rows.every((r) => r.subtask_id === "configure-board")).toBe(true);
+      expect(rows.map((r) => r.spawn_index)).toEqual([0, 1, 2]);
+      expect(rows.every((r) => r.status === "ready")).toBe(true);
+      expect(rows.map((r) => JSON.parse(r.input_json))).toEqual([
+        { board: { alias: "a" } },
+        { board: { alias: "b" } },
+        { board: { alias: "c" } },
+      ]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("returns [] when the parent has no spawns directive", () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-N",
+        NO_SPAWN_PIPELINE_ID,
+        "first",
+        "p_first",
+        h.nowFn(),
+      );
+      const ids = applySpawns(
+        h.db,
+        "p_first",
+        "run-N",
+        NO_SPAWN_PIPELINE_DEF.subtasks[0],
+        { score: 1 },
+        h.nowFn(),
+        () => "child_x",
+      );
+      expect(ids).toEqual([]);
+      const rows = h.db
+        .prepare(`SELECT COUNT(*) AS c FROM subtask_instances WHERE run_id = ?`)
+        .get("run-N") as { c: number };
+      expect(rows.c).toBe(1); // just the parent
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("inserts duplicate-bind children when the for_each array has duplicates (no dedup)", () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-D",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      let i = 0;
+      applySpawns(
+        h.db,
+        "p_parent",
+        "run-D",
+        SPAWN_PIPELINE_DEF.subtasks[0],
+        { boards: [{ alias: "dup" }, { alias: "dup" }] },
+        h.nowFn(),
+        () => {
+          i += 1;
+          return `dup_${i}`;
+        },
+      );
+      const rows = h.db
+        .prepare(
+          `SELECT input_json FROM subtask_instances
+            WHERE parent_instance_id = ? ORDER BY spawn_index`,
+        )
+        .all("p_parent") as ReadonlyArray<{ input_json: string }>;
+      expect(rows.length).toBe(2);
+      expect(rows.map((r) => JSON.parse(r.input_json))).toEqual([
+        { board: { alias: "dup" } },
+        { board: { alias: "dup" } },
+      ]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("inserts nothing when the for_each field is missing in output", () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-M",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const ids = applySpawns(
+        h.db,
+        "p_parent",
+        "run-M",
+        SPAWN_PIPELINE_DEF.subtasks[0],
+        // Note: schema would reject this in production. Defence-in-depth.
+        { other: "data" },
+        h.nowFn(),
+        () => "should_not_be_called",
+      );
+      expect(ids).toEqual([]);
+      const rows = h.db
+        .prepare(
+          `SELECT COUNT(*) AS c FROM subtask_instances
+            WHERE parent_instance_id = ?`,
+        )
+        .get("p_parent") as { c: number };
+      expect(rows.c).toBe(0);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("inserts nothing for an empty for_each array", () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-E",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const ids = applySpawns(
+        h.db,
+        "p_parent",
+        "run-E",
+        SPAWN_PIPELINE_DEF.subtasks[0],
+        { boards: [] },
+        h.nowFn(),
+        () => "should_not_be_called",
+      );
+      expect(ids).toEqual([]);
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+/* ---------- End-to-end through the CAS submit ---------- */
+
+describe("M8 spawns runtime — end-to-end through submit", () => {
+  it("Pipeline with list-boards + boards: [a, b, c] submission → exactly 3 rows with bind set to a/b/c", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+
+      // The parent is ready; claim it.
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      // Submit the parent's output containing the boards array.
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { boards: [{ alias: "a" }, { alias: "b" }, { alias: "c" }] } },
+      );
+      expect(submit.body.ok).toBe(true);
+
+      const children = h.db
+        .prepare(
+          `SELECT subtask_id, status, parent_instance_id, spawn_index, input_json
+             FROM subtask_instances
+            WHERE parent_instance_id = 'p_parent'
+            ORDER BY spawn_index`,
+        )
+        .all() as ReadonlyArray<{
+        subtask_id: string;
+        status: string;
+        parent_instance_id: string;
+        spawn_index: number;
+        input_json: string;
+      }>;
+      expect(children.length).toBe(3);
+      expect(children.every((r) => r.subtask_id === "configure-board")).toBe(
+        true,
+      );
+      expect(children.every((r) => r.status === "ready")).toBe(true);
+      expect(children.every((r) => r.parent_instance_id === "p_parent")).toBe(
+        true,
+      );
+      expect(children.map((r) => JSON.parse(r.input_json))).toEqual([
+        { board: { alias: "a" } },
+        { board: { alias: "b" } },
+        { board: { alias: "c" } },
+      ]);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("Empty boards array → no rows inserted; agent_actions records the no-op (the parent's submit_result row IS the audit)", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-E",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      const submit = await postJson<SubmitOkData>(
+        h.app,
+        `/${token}/result`,
+        { result: { boards: [] } },
+      );
+      expect(submit.body.ok).toBe(true);
+
+      const children = h.db
+        .prepare(
+          `SELECT COUNT(*) AS c FROM subtask_instances
+            WHERE parent_instance_id = 'p_parent'`,
+        )
+        .get() as { c: number };
+      expect(children.c).toBe(0);
+
+      // The parent's submit_result audit row is recorded — that IS the
+      // no-op record; we do not want a separate "spawn fired 0 children"
+      // row that bloats the audit log.
+      const actions = h.db
+        .prepare(
+          `SELECT kind FROM agent_actions
+            WHERE instance_id = 'p_parent' AND kind = 'submit_result'`,
+        )
+        .all() as ReadonlyArray<{ kind: string }>;
+      expect(actions.length).toBeGreaterThan(0);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("Children all have status='ready' and are claimable via /work/next", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+      const submit = await postJson<SubmitOkData>(h.app, `/${token}/result`, {
+        result: { boards: [{ alias: "a" }, { alias: "b" }] },
+      });
+      expect(submit.body.ok).toBe(true);
+
+      // Two children should now be claimable in order.
+      const c1 = await getJson<NextWorkData>(h.app, "/next");
+      if (!c1.body.ok || !c1.body.data) throw new Error("expected child claim 1");
+      expect(c1.body.data.instructions).toBe("Configure this board.");
+      expect(c1.body.data.input).toEqual({ board: { alias: "a" } });
+
+      const c2 = await getJson<NextWorkData>(h.app, "/next");
+      if (!c2.body.ok || !c2.body.data) throw new Error("expected child claim 2");
+      expect(c2.body.data.input).toEqual({ board: { alias: "b" } });
+
+      const c3 = await getJson<NextWorkData | null>(h.app, "/next");
+      // No third child.
+      expect(c3.body.ok).toBe(true);
+      if (c3.body.ok) expect(c3.body.data).toBeNull();
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("parent_instance_id is set correctly", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+      await postJson<SubmitOkData>(h.app, `/${token}/result`, {
+        result: { boards: [{ alias: "x" }] },
+      });
+
+      const child = h.db
+        .prepare(
+          `SELECT parent_instance_id FROM subtask_instances
+            WHERE subtask_id = 'configure-board'`,
+        )
+        .get() as { parent_instance_id: string | null } | undefined;
+      expect(child?.parent_instance_id).toBe("p_parent");
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("After all children submit, run is marked complete (no spawn re-fires)", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+
+      // Parent submit → spawns 2 children.
+      const parent = await getJson<NextWorkData>(h.app, "/next");
+      if (!parent.body.ok || !parent.body.data) throw new Error("expected claim");
+      await postJson<SubmitOkData>(h.app, `/${parent.body.data.claim}/result`, {
+        result: { boards: [{ alias: "a" }, { alias: "b" }] },
+      });
+
+      // Drain both children.
+      for (let i = 0; i < 2; i += 1) {
+        const c = await getJson<NextWorkData>(h.app, "/next");
+        if (!c.body.ok || !c.body.data) throw new Error("expected child claim");
+        const r = await postJson<SubmitOkData>(
+          h.app,
+          `/${c.body.data.claim}/result`,
+          { result: { ok: true } },
+        );
+        expect(r.body.ok).toBe(true);
+      }
+
+      // Run flipped to completed.
+      const run = h.db
+        .prepare(
+          `SELECT status, completed_at FROM runs WHERE id = 'run-A'`,
+        )
+        .get() as { status: string; completed_at: string | null } | undefined;
+      expect(run?.status).toBe("completed");
+      expect(typeof run?.completed_at).toBe("string");
+
+      // No additional rows beyond parent + 2 children appeared.
+      const total = h.db
+        .prepare(`SELECT COUNT(*) AS c FROM subtask_instances WHERE run_id = 'run-A'`)
+        .get() as { c: number };
+      expect(total.c).toBe(3);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("Pipeline without spawns directive → no extra rows", async () => {
+    const h = makeHarness();
+    try {
+      // Use the no-spawn pipeline and seed two ready+pending instances.
+      h.db.prepare(
+        `INSERT INTO runs
+           (id, pipeline_id, pipeline_version, status, initial_input_json,
+            webhook_url, created_at)
+         VALUES (?, ?, ?, 'running', '{}', 'https://example.test/webhook', ?)`,
+      ).run("run-N", NO_SPAWN_PIPELINE_ID, SPAWN_PIPELINE_VERSION, h.nowFn());
+      h.db.prepare(
+        `INSERT INTO subtask_instances
+           (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, '{}', ?, ?)`,
+      ).run("p_first", "run-N", "first", "ready", h.nowFn(), h.nowFn());
+      h.db.prepare(
+        `INSERT INTO subtask_instances
+           (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, '{}', ?, ?)`,
+      ).run(
+        "p_second",
+        "run-N",
+        "second",
+        "pending",
+        new Date(new Date(h.nowFn()).getTime() + 1).toISOString(),
+        h.nowFn(),
+      );
+
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      await postJson<SubmitOkData>(
+        h.app,
+        `/${claim.body.data.claim}/result`,
+        { result: { score: 1 } },
+      );
+
+      const total = h.db
+        .prepare(`SELECT COUNT(*) AS c FROM subtask_instances WHERE run_id = 'run-N'`)
+        .get() as { c: number };
+      // No spawn ⇒ exactly the two seeded rows.
+      expect(total.c).toBe(2);
+    } finally {
+      h.db.close();
+    }
+  });
+
+  it("bind is the canonical input shape passed to the child's pull_task payload (verified end-to-end)", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      await postJson<SubmitOkData>(
+        h.app,
+        `/${claim.body.data.claim}/result`,
+        {
+          result: {
+            boards: [{ alias: "careers-de", url: "https://x.test/de" }],
+          },
+        },
+      );
+
+      // Pull the child task; verify the agent-facing input is the bound element.
+      const child = await getJson<NextWorkData>(h.app, "/next");
+      if (!child.body.ok || !child.body.data) {
+        throw new Error("expected child claim");
+      }
+      expect(child.body.data.input).toEqual({
+        board: { alias: "careers-de", url: "https://x.test/de" },
+      });
+    } finally {
+      h.db.close();
+    }
+  });
+});
+
+/* ---------- Atomicity ---------- */
+
+describe("M8 spawns runtime — atomicity", () => {
+  it("a forced error mid-spawn rolls back: no spawn rows persist and parent stays claimed", async () => {
+    const h = makeHarness();
+    try {
+      seedRunWithParent(
+        h.db,
+        "run-A",
+        SPAWN_PIPELINE_ID,
+        "list-boards",
+        "p_parent",
+        h.nowFn(),
+      );
+      const claim = await getJson<NextWorkData>(h.app, "/next");
+      if (!claim.body.ok || !claim.body.data) throw new Error("expected claim");
+      const token = claim.body.data.claim;
+
+      // Patch JSON.stringify to throw the second time it's called inside
+      // spawn-row insertion. We can't easily mock the prepared statement
+      // through the Hono request, so we sabotage one of the row's
+      // input_json encodings — which sits inside the txn AFTER the parent
+      // CAS UPDATE. The expected outcome: the whole txn rolls back, the
+      // parent goes back to `claimed` (NOT `done`), and zero spawn rows
+      // exist.
+      //
+      // Implementation: wrap better-sqlite3's INSERT for the spawn child
+      // and force it to throw on the SECOND call (the first call inserts
+      // child #0 successfully; the throw on #1 must roll back #0).
+      let calls = 0;
+      const originalPrepare = h.db.prepare.bind(h.db);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test seam: the harness wraps better-sqlite3's prepare to inject a fault on the spawn insert; wrapping is generic and the (...args: any[]) bridge mirrors the underlying API surface that we don't fully model here.
+      (h.db as any).prepare = (sql: string) => {
+        const stmt = originalPrepare(sql);
+        if (sql.includes("INSERT INTO subtask_instances") && sql.includes("parent_instance_id")) {
+          const realRun = stmt.run.bind(stmt);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          stmt.run = ((...args: any[]) => {
+            calls += 1;
+            if (calls === 2) {
+              throw new Error("synthetic mid-spawn failure");
+            }
+            return realRun(...args);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any;
+        }
+        return stmt;
+      };
+
+      // Submit; the route's outer try/catch surfaces the thrown error
+      // as an unhandled error → Hono returns 500. We don't assert on the
+      // shape of the 500; we assert on the DB state.
+      let threw = false;
+      try {
+        await postJson<SubmitOkData>(h.app, `/${token}/result`, {
+          result: { boards: [{ alias: "x" }, { alias: "y" }, { alias: "z" }] },
+        });
+      } catch {
+        threw = true;
+      }
+      // Hono catches the throw and turns it into a 500; the request
+      // promise resolves with that response, so `threw` is usually false.
+      // The atomicity assertion that follows is what matters.
+      void threw;
+
+      const parent = h.db
+        .prepare(`SELECT status FROM subtask_instances WHERE id = 'p_parent'`)
+        .get() as { status: string } | undefined;
+      // CAS UPDATE rolled back → parent is still `claimed` (the CAS that
+      // flipped it to `done` was inside the same txn).
+      expect(parent?.status).toBe("claimed");
+
+      const spawned = h.db
+        .prepare(
+          `SELECT COUNT(*) AS c FROM subtask_instances
+            WHERE parent_instance_id = 'p_parent'`,
+        )
+        .get() as { c: number };
+      expect(spawned.c).toBe(0);
+
+      // Run still running.
+      const run = h.db
+        .prepare(`SELECT status FROM runs WHERE id = 'run-A'`)
+        .get() as { status: string } | undefined;
+      expect(run?.status).toBe("running");
+    } finally {
+      h.db.close();
+    }
+  });
+});

--- a/src/api/agent/spawns.test.ts
+++ b/src/api/agent/spawns.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import type Database from "better-sqlite3";
 
-import type { EnvelopeResponse } from "@murmur/contracts-types";
+import type { EnvelopeResponse, SubtaskDef } from "@murmur/contracts-types";
 
 import { openDb } from "../../db/index.js";
 import { runMigrations } from "../../db/migrate.js";
@@ -26,6 +26,22 @@ import {
 import type { NextWorkData, SubmitOkData } from "./work.js";
 
 /**
+ * Look up a subtask def by id from a pipeline-def-shaped object. Throws
+ * (rather than returning `undefined`) so the test's typecheck stays
+ * strict — every test that uses this expects the def to exist.
+ */
+function findSubtask(
+  def: { subtasks: ReadonlyArray<SubtaskDef> },
+  id: string,
+): SubtaskDef {
+  const found = def.subtasks.find((s) => s.id === id);
+  if (found === undefined) {
+    throw new Error(`subtask def not found: ${id}`);
+  }
+  return found;
+}
+
+/**
  * Pipeline def used by spawn tests. `list-boards` declares
  * `spawns: { for_each, template, bind_as }`; `configure-board` is the
  * spawn template. Schemas are deliberately permissive but require the
@@ -34,7 +50,17 @@ import type { NextWorkData, SubmitOkData } from "./work.js";
 const SPAWN_PIPELINE_ID = "spawn-pipeline";
 const SPAWN_PIPELINE_VERSION = 1;
 
-const SPAWN_PIPELINE_DEF = {
+interface PipelineDefForTest {
+  readonly id: string;
+  readonly initial_input: Readonly<Record<string, unknown>>;
+  readonly subtasks: ReadonlyArray<SubtaskDef>;
+  readonly final_output: {
+    readonly composes: ReadonlyArray<string>;
+    readonly webhook: string;
+  };
+}
+
+const SPAWN_PIPELINE_DEF: PipelineDefForTest = {
   id: SPAWN_PIPELINE_ID,
   initial_input: { type: "object" },
   subtasks: [
@@ -77,7 +103,7 @@ const SPAWN_PIPELINE_DEF = {
  * `requires` the other, no `spawns:`.
  */
 const NO_SPAWN_PIPELINE_ID = "no-spawn-pipeline";
-const NO_SPAWN_PIPELINE_DEF = {
+const NO_SPAWN_PIPELINE_DEF: PipelineDefForTest = {
   id: NO_SPAWN_PIPELINE_ID,
   initial_input: { type: "object" },
   subtasks: [
@@ -296,7 +322,7 @@ describe("applySpawns", () => {
         h.db,
         "p_parent",
         "run-A",
-        SPAWN_PIPELINE_DEF.subtasks[0],
+        findSubtask(SPAWN_PIPELINE_DEF, "list-boards"),
         { boards: [{ alias: "a" }, { alias: "b" }, { alias: "c" }] },
         h.nowFn(),
         () => {
@@ -354,7 +380,7 @@ describe("applySpawns", () => {
         h.db,
         "p_first",
         "run-N",
-        NO_SPAWN_PIPELINE_DEF.subtasks[0],
+        findSubtask(NO_SPAWN_PIPELINE_DEF, "first"),
         { score: 1 },
         h.nowFn(),
         () => "child_x",
@@ -385,7 +411,7 @@ describe("applySpawns", () => {
         h.db,
         "p_parent",
         "run-D",
-        SPAWN_PIPELINE_DEF.subtasks[0],
+        findSubtask(SPAWN_PIPELINE_DEF, "list-boards"),
         { boards: [{ alias: "dup" }, { alias: "dup" }] },
         h.nowFn(),
         () => {
@@ -424,7 +450,7 @@ describe("applySpawns", () => {
         h.db,
         "p_parent",
         "run-M",
-        SPAWN_PIPELINE_DEF.subtasks[0],
+        findSubtask(SPAWN_PIPELINE_DEF, "list-boards"),
         // Note: schema would reject this in production. Defence-in-depth.
         { other: "data" },
         h.nowFn(),
@@ -458,7 +484,7 @@ describe("applySpawns", () => {
         h.db,
         "p_parent",
         "run-E",
-        SPAWN_PIPELINE_DEF.subtasks[0],
+        findSubtask(SPAWN_PIPELINE_DEF, "list-boards"),
         { boards: [] },
         h.nowFn(),
         () => "should_not_be_called",

--- a/src/api/agent/spawns.ts
+++ b/src/api/agent/spawns.ts
@@ -34,23 +34,6 @@ import type Database from "better-sqlite3";
 import type { SpawnsDef, SubtaskDef } from "@murmur/contracts-types";
 
 /**
- * The columns we INSERT for each spawned child. Mirrors the
- * `subtask_instances` schema in `src/db/schema.md`. `claim_token` and
- * `expires_at` default to NULL (the row is freshly `ready`, not claimed).
- */
-export interface SpawnedChildRow {
-  readonly id: string;
-  readonly run_id: string;
-  readonly subtask_id: string;
-  readonly parent_instance_id: string;
-  readonly spawn_index: number;
-  readonly status: "ready";
-  readonly input_json: string;
-  readonly created_at: string;
-  readonly updated_at: string;
-}
-
-/**
  * Compute the child input payload that the spawned subtask will see in
  * its `pull_task` (`/work/next`) response under `data.input`.
  *
@@ -142,14 +125,33 @@ export function applySpawns(
   now: string,
   mintInstanceId: () => string,
 ): ReadonlyArray<string> {
-  void db;
-  void parentInstanceId;
-  void parentRunId;
-  void parentSubtaskDef;
-  void output;
-  void now;
-  void mintInstanceId;
-  throw new Error("not implemented");
+  const spawns = parentSubtaskDef.spawns;
+  if (spawns === undefined) return [];
+
+  const elements = extractForEachArray(output, spawns.for_each);
+  if (elements === null || elements.length === 0) return [];
+
+  const insertStmt = db.prepare(INSERT_SPAWN_CHILD_SQL);
+  const ids: string[] = [];
+
+  for (let i = 0; i < elements.length; i += 1) {
+    const id = mintInstanceId();
+    const childInput = bindChildInput(spawns, elements[i]);
+    insertStmt.run({
+      id,
+      run_id: parentRunId,
+      subtask_id: spawns.template,
+      parent_instance_id: parentInstanceId,
+      spawn_index: i,
+      status: "ready",
+      input_json: JSON.stringify(childInput),
+      created_at: now,
+      updated_at: now,
+    });
+    ids.push(id);
+  }
+
+  return ids;
 }
 
 /**

--- a/src/api/agent/spawns.ts
+++ b/src/api/agent/spawns.ts
@@ -1,0 +1,169 @@
+/**
+ * `spawns` runtime — instantiates one `subtask_instances` child row per
+ * element of the parent's `output[for_each]` array (DESIGN.md §3.1, M8).
+ *
+ * Called from `src/api/agent/lifecycle.ts#spawnChildren`, itself called
+ * from `src/api/agent/work.ts` inside the same `BEGIN IMMEDIATE`
+ * transaction as the parent's CAS submit. Atomicity is the caller's
+ * responsibility — this module performs INSERTs only and surfaces
+ * thrown errors verbatim so the caller can ROLLBACK.
+ *
+ * Semantics (DESIGN.md §3.1, worked `list-boards` → `configure-board`
+ * example, lines 172–175):
+ *
+ *   - The `spawns:` block lives on the *parent* subtask def.
+ *   - `for_each` names a top-level field on the parent's submitted
+ *     output. The field's value MUST be an array; missing-or-non-array
+ *     is treated as zero-spawn (the empty-array path) per the issue's
+ *     "for-each field missing in output" edge case.
+ *   - `template` names the subtask def to use for each child. The
+ *     template is NOT in the run-start ready set (see
+ *     `src/api/publisher/ready_set.ts#spawnTemplateIds`); spawned rows
+ *     are the only way it gets instances.
+ *   - `bind_as` (optional, M8) names the input key under which the child
+ *     sees the for_each element. If omitted the element is the entire
+ *     input; if set the input is `{ [bind_as]: <element> }`.
+ *
+ * @see DESIGN.md §3.1 — `spawns` schema field + jobseek worked example
+ * @see src/api/agent/lifecycle.ts — call site, `spawnChildren`
+ * @see src/api/agent/work.ts — outer transaction
+ */
+
+import type Database from "better-sqlite3";
+
+import type { SpawnsDef, SubtaskDef } from "@murmur/contracts-types";
+
+/**
+ * The columns we INSERT for each spawned child. Mirrors the
+ * `subtask_instances` schema in `src/db/schema.md`. `claim_token` and
+ * `expires_at` default to NULL (the row is freshly `ready`, not claimed).
+ */
+export interface SpawnedChildRow {
+  readonly id: string;
+  readonly run_id: string;
+  readonly subtask_id: string;
+  readonly parent_instance_id: string;
+  readonly spawn_index: number;
+  readonly status: "ready";
+  readonly input_json: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+/**
+ * Compute the child input payload that the spawned subtask will see in
+ * its `pull_task` (`/work/next`) response under `data.input`.
+ *
+ * If the parent's `spawns.bind_as` is set, the input is
+ * `{ [bind_as]: <element> }`. Otherwise the input is the element itself.
+ *
+ * Exported for unit tests; production callers go through {@link applySpawns}.
+ *
+ * @param spawns the parent's validated `SpawnsDef`.
+ * @param element one element of the parent's `output[for_each]` array.
+ * @returns a JSON-serialisable input document for the child instance.
+ */
+export function bindChildInput(spawns: SpawnsDef, element: unknown): unknown {
+  if (spawns.bind_as !== undefined && spawns.bind_as.length > 0) {
+    return { [spawns.bind_as]: element };
+  }
+  return element;
+}
+
+/**
+ * Read `output[for_each]` and return it as a JS array IFF it is one.
+ * Anything else (`undefined`, non-object output, non-array field, null)
+ * yields `null` — which the caller treats as "no spawn fires".
+ *
+ * Per the issue's edge cases:
+ *   - "For-each field missing in output (schema should catch first; if
+ *     it slips through, no spawn fires)" → return null.
+ *   - "Empty array → no rows inserted" → return `[]`. The caller still
+ *     audits the no-op via the parent's existing `submit_result` row;
+ *     no separate audit row is written.
+ *
+ * Exported for unit tests; production callers go through {@link applySpawns}.
+ *
+ * @param output the parent's submitted (already-schema-validated) result.
+ * @param fieldName the `for_each` field name (DESIGN.md §3.1's flat
+ *   single-field shape; not a JSON Pointer or dotted path).
+ * @returns the array (possibly empty), or `null` when the field is
+ *   absent / not an array.
+ */
+export function extractForEachArray(
+  output: unknown,
+  fieldName: string,
+): ReadonlyArray<unknown> | null {
+  if (output === null || typeof output !== "object" || Array.isArray(output)) {
+    return null;
+  }
+  const value = (output as Record<string, unknown>)[fieldName];
+  if (!Array.isArray(value)) return null;
+  return value;
+}
+
+/**
+ * Instantiate spawn children for a just-submitted parent.
+ *
+ * Behaviour:
+ *
+ *   - If `parentSubtaskDef.spawns` is undefined → return `[]` (no-op).
+ *     This is the "pipeline without a `spawns` directive" path.
+ *   - If `output[spawns.for_each]` is not an array → return `[]`. The
+ *     missing-field edge case.
+ *   - Otherwise insert one `subtask_instances` row per array element, in
+ *     order, with `status='ready'`, `parent_instance_id=parentInstanceId`,
+ *     `spawn_index = i`, and `input_json = JSON.stringify(bindChildInput(...))`.
+ *     Returns the spawned ids in insertion order. Duplicate elements
+ *     produce two children (no dedup) — the issue explicitly allows this.
+ *
+ * Inserts happen on the caller-supplied `db` connection. The caller is
+ * responsible for the surrounding transaction (see `work.ts` —
+ * `BEGIN IMMEDIATE` wraps `casStmt` + `markNextReady` + this call).
+ *
+ * @param db an open better-sqlite3 connection.
+ * @param parentInstanceId the just-completed parent's `subtask_instances.id`.
+ * @param parentRunId the run id (children inherit it).
+ * @param parentSubtaskDef the parent's `SubtaskDef` (must include the
+ *   `spawns` block when relevant; passing a def without `spawns` is a no-op).
+ * @param output the parent's submitted, schema-validated result.
+ * @param now an RFC 3339 UTC string used as `created_at` and `updated_at`.
+ * @param mintInstanceId function called once per spawned row to mint a
+ *   fresh, unique `subtask_instances.id`. Injected so tests can stub.
+ * @returns the spawned child instance ids in insertion order.
+ *   Empty array when no spawn fires.
+ */
+export function applySpawns(
+  db: Database.Database,
+  parentInstanceId: string,
+  parentRunId: string,
+  parentSubtaskDef: SubtaskDef,
+  output: unknown,
+  now: string,
+  mintInstanceId: () => string,
+): ReadonlyArray<string> {
+  void db;
+  void parentInstanceId;
+  void parentRunId;
+  void parentSubtaskDef;
+  void output;
+  void now;
+  void mintInstanceId;
+  throw new Error("not implemented");
+}
+
+/**
+ * Prepared INSERT for one spawned child row. Bound parameters mirror the
+ * full `subtask_instances` insert in `src/api/publisher/pipelines.ts` but
+ * also populate `parent_instance_id` and `spawn_index` (which the
+ * publisher's run-start path leaves NULL).
+ */
+export const INSERT_SPAWN_CHILD_SQL = `
+INSERT INTO subtask_instances (
+  id, run_id, subtask_id, parent_instance_id, spawn_index,
+  status, input_json, created_at, updated_at
+) VALUES (
+  @id, @run_id, @subtask_id, @parent_instance_id, @spawn_index,
+  @status, @input_json, @created_at, @updated_at
+)
+`;

--- a/src/api/agent/work.ts
+++ b/src/api/agent/work.ts
@@ -37,6 +37,7 @@ import type Database from "better-sqlite3";
 import type { Err, Ok } from "@murmur/contracts-types";
 
 import { validateAgainst } from "../../dispatch/validation.js";
+import { newInstanceId } from "../publisher/ids.js";
 
 import {
   CAS_SQL,
@@ -78,6 +79,12 @@ export interface CreateWorkRoutesOptions {
   readonly nowFn?: () => string;
   /** Returns a fresh claim token (opaque, ≥16 bytes of entropy). */
   readonly claimTokenFn?: () => string;
+  /**
+   * Returns a fresh `subtask_instances.id` for spawn children. Defaults
+   * to {@link newInstanceId} (12 random bytes hex-encoded). Tests inject
+   * a deterministic counter so spawned ids match assertions.
+   */
+  readonly instanceIdFn?: () => string;
 }
 
 /**
@@ -156,6 +163,7 @@ export function createWorkRoutes(options: CreateWorkRoutesOptions): Hono {
   const ttlMs = options.ttlMs ?? DEFAULT_CLAIM_TTL_MS;
   const nowFn = options.nowFn ?? (() => nowIso());
   const claimTokenFn = options.claimTokenFn ?? freshClaimToken;
+  const instanceIdFn = options.instanceIdFn ?? newInstanceId;
 
   // Compile the prepared statements once at construction time. Re-binding
   // happens on every call but the parse step runs once.
@@ -376,11 +384,13 @@ export function createWorkRoutes(options: CreateWorkRoutesOptions): Hono {
           args.truncated || resp.truncated ? 1 : 0,
         );
 
-        // Mark next ready set inside the same transaction.
+        // Spawn children FIRST so their freshly-`ready` rows are
+        // visible to `markNextReady` (DAG-following pendings that
+        // depend on the spawn template's id are advanced in the same
+        // round). Run-completion check runs LAST so it sees the new
+        // pending/ready rows that spawns just inserted.
+        spawnChildren(db, casRow.id, validation.value, now, instanceIdFn);
         markNextReady(db, casRow.run_id, now);
-
-        // M8 stub: spawn children. M10 stub: maybe finalise run.
-        spawnChildren(db, casRow.id, validation.value, now);
         maybeFinaliseRun(db, casRow.run_id, now);
 
         db.exec("COMMIT");


### PR DESCRIPTION
## Summary
Replaces the documented `spawnChildren` stub with a real implementation: when a parent subtask declares `spawns: { for_each, template, bind_as? }`, the CAS submit handler instantiates one `subtask_instances` row per element of the parent's output array, in order, inside the same `BEGIN IMMEDIATE` transaction as the parent's flip to `done`. Also flips the run to `completed` once every instance reaches a terminal state — webhook delivery and `final_output` composition stay TODOs against M10 / M11.

## Related issue
Closes colophon-group/murmur#13

## Files changed (high-level)
- `src/api/agent/spawns.ts` — new module. `applySpawns`, `bindChildInput`, `extractForEachArray`, `INSERT_SPAWN_CHILD_SQL`.
- `src/api/agent/lifecycle.ts` — `spawnChildren` now delegates to `applySpawns` (looks up parent's run/subtask/def). `maybeFinaliseRun` flips to `completed` (idempotent). Adds `lookupParentForSpawn` and `lookupSubtaskDef` helpers.
- `src/api/agent/work.ts` — threads a `mintInstanceId` (defaults to `newInstanceId`) through to `spawnChildren`. Reorders the lifecycle calls so spawned children are visible to `markNextReady` and the run-completion check sees them.
- `packages/contracts-types/src/pipeline.ts` — adds optional `bind_as?: string` to `SpawnsDef`.
- `docs/contracts/pipeline-def.schema.json` — adds optional `bind_as` to the `Spawns` def.
- `docs/contracts.md` — documents `bind_as` in the pipeline-def cheatsheet.
- `src/api/agent/spawns.test.ts` — every Verification bullet from #13 + edge cases + atomicity rollback.

## Verification (from the issue)
- [x] Pipeline with `list-boards` (spawns→`configure-board`) + `boards: [a, b, c]` submission → exactly 3 rows inserted with `bind` set to a/b/c
- [x] Empty boards array → no rows inserted; `agent_actions` records the no-op (the parent's `submit_result` row is the audit)
- [x] Children all have `status='ready'` and are claimable via `/work/next`
- [x] `parent_instance_id` is set correctly
- [x] After all children submit, run is marked complete (no spawn re-fires)
- [x] Pipeline without `spawns` directive → no extra rows
- [x] `bind` is the canonical input shape passed to the child's `pull_task` payload (verified end-to-end)
- [x] For-each field missing in output → no spawn fires
- [x] Duplicate items in for_each → 2 children with same `bind` value (allowed; no dedup)
- [x] Atomicity: a forced error mid-spawn rolls back (no spawn rows persist + parent stays `claimed`)

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓ (incl. `check-unused-exports`)
- `pnpm test` ✓ (174 root tests + 34 contracts-types tests, all green)
- Coverage: `src/api/**` at 92.46% lines / 80.76% branches (gate is 85/75; all spawn paths covered, lifecycle.ts at 96.74%)
- `pnpm grep:all` ✓
- `pnpm build` ✓

## Notes for reviewer
- `bind_as` semantics follow DESIGN.md §3.1's worked example (`bind_as: board`). When set, child input is `{ [bind_as]: element }`; when omitted, child input is the element verbatim. Made `bind_as` optional in both the JSON schema and the TS type so existing pipelines without it (the all-seven fixture) keep validating.
- `maybeFinaliseRun` flips `runs.status` to `completed` and sets `completed_at`. It does NOT compose `final_output` or POST the webhook — those land in M11 / M10 (#19 / #18). The flip is the deterministic precondition both depend on; the verification bullet "After all children submit, run is marked complete" needed it.
- The atomicity test patches `db.prepare` to inject a synthetic throw on the second spawn-child INSERT. The test then asserts (a) parent stays `claimed` (CAS rolled back), (b) zero spawn rows persisted, (c) run still `running`. Hono's outer try/catch turns the throw into a 500; we don't assert on that — the DB invariant is the contract.
- Spawn order in `work.ts`: spawns INSERT → `markNextReady` → `maybeFinaliseRun`. Spawns must come first so freshly-`ready` children are visible when `markNextReady` walks pending rows (a hypothetical pipeline where a static subtask `requires: [configure-board]` would otherwise miss). `maybeFinaliseRun` last so it doesn't false-positive when spawns just inserted new pending/ready rows.