### PR TITLE
feat(dispatch): task_tool dispatch with publisher HTTP proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.9.0",
-    "yaml": "^2.8.3",
-    "zod": "^4.3.6"
+    "undici": "^7.6.0"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.9.0",
-    "undici": "^7.6.0"
+    "undici": "^7.6.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.9.0",
     "undici": "^7.6.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@hono/node-server": "1.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,9 @@ importers:
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
-      yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
-      zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+      undici:
+        specifier: ^7.6.0
+        version: 7.25.0
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
@@ -1818,9 +1815,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1921,11 +1918,6 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
-
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3598,7 +3590,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  unpipe@1.0.0: {}
+  undici@7.25.0: {}
 
   uri-js@4.4.1:
     dependencies:
@@ -3696,8 +3688,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   yaml@1.10.3: {}
-
-  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       undici:
         specifier: ^7.6.0
         version: 7.25.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7
@@ -1919,6 +1922,11 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3688,6 +3696,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1822,6 +1822,10 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -3599,6 +3603,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici@7.25.0: {}
+
+  unpipe@1.0.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@hono/node-server':
         specifier: 1.13.7

--- a/src/dispatch/audit.ts
+++ b/src/dispatch/audit.ts
@@ -59,5 +59,18 @@ export interface TruncatedAuditField {
  * @returns the (possibly clipped) text and the truncated flag.
  */
 export function truncateForAudit(json: string | null): TruncatedAuditField {
-  throw new Error("not implemented");
+  if (json === null) {
+    return { text: null, truncated: false };
+  }
+  const byteLen = Buffer.byteLength(json, "utf8");
+  if (byteLen <= AUDIT_PAYLOAD_LIMIT_BYTES) {
+    return { text: json, truncated: false };
+  }
+  // Slice at the byte cap, then drop trailing partial UTF-8 sequences
+  // by decoding permissively and stripping replacement chars at the end.
+  const buf = Buffer.from(json, "utf8");
+  const slice = buf.subarray(0, AUDIT_PAYLOAD_LIMIT_BYTES);
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(slice);
+  const cleaned = decoded.replace(/�+$/u, "");
+  return { text: cleaned, truncated: true };
 }

--- a/src/dispatch/audit.ts
+++ b/src/dispatch/audit.ts
@@ -1,0 +1,63 @@
+/**
+ * Audit-log payload truncation for `task_tool` dispatch (DESIGN.md §3.6).
+ *
+ * `agent_actions.args_json` and `agent_actions.response_json` are capped
+ * at 4 KB UTF-8 bytes. Truncation is silent — DESIGN.md §3.6 explicitly
+ * cuts the per-field `_truncated` map for MVP. The single boolean
+ * `agent_actions.truncated` column flags the row when EITHER field was
+ * clipped, so the `GET /runs/{id}` consumer can flag the row in the UI.
+ *
+ * Why a separate file from `validation.ts`: the orchestrator note for
+ * issue #12 instructs not to modify `validation.ts`. The truncation
+ * helper is a dispatch-layer concern (the only consumer is the
+ * `task_tool` audit row writer), so it lives next to the dispatcher.
+ *
+ * Why not import the `truncatePayload` helper at
+ * `src/api/publisher/truncate.ts`: that helper has read-time semantics
+ * (1 KB cap with a `…(truncated)` marker stitched onto the string), used
+ * by `GET /runs/{id}` to keep audit polls scannable. The DB write-time
+ * cap is 4 KB and the marker isn't part of the wire format. Keeping the
+ * two helpers separate prevents a future tweak to the read-time helper
+ * from accidentally changing what gets written to the DB.
+ *
+ * @see DESIGN.md §3.6 — Audit log payload truncation
+ */
+
+/**
+ * Per-field byte cap on `agent_actions.args_json` and
+ * `agent_actions.response_json`. UTF-8 bytes, not code points.
+ */
+export const AUDIT_PAYLOAD_LIMIT_BYTES = 4 * 1024;
+
+/**
+ * Result shape for {@link truncateForAudit}.
+ *
+ * - `text`: the (possibly clipped) JSON string, or `null` if input was `null`.
+ * - `truncated`: `true` iff the input exceeded {@link AUDIT_PAYLOAD_LIMIT_BYTES}.
+ */
+export interface TruncatedAuditField {
+  readonly text: string | null;
+  readonly truncated: boolean;
+}
+
+/**
+ * Truncate a JSON string field to {@link AUDIT_PAYLOAD_LIMIT_BYTES}
+ * UTF-8 bytes for storage in the `agent_actions` table.
+ *
+ * Behaviour:
+ *   - `null` input → `{ text: null, truncated: false }`. The DB columns
+ *     are nullable; preserve nulls.
+ *   - input within cap → returned unchanged, `truncated: false`.
+ *   - input above cap → clipped on a UTF-8 boundary (never splits a
+ *     multi-byte sequence; trailing partial bytes are dropped).
+ *     `truncated: true`. NO marker is appended — DESIGN.md §3.6 says
+ *     truncation is silent for MVP; the per-row `truncated` flag carries
+ *     the signal.
+ *
+ * @param json - the candidate string from `JSON.stringify(value)` or
+ *               `null` for "no value".
+ * @returns the (possibly clipped) text and the truncated flag.
+ */
+export function truncateForAudit(json: string | null): TruncatedAuditField {
+  throw new Error("not implemented");
+}

--- a/src/dispatch/task_tool.test.ts
+++ b/src/dispatch/task_tool.test.ts
@@ -238,8 +238,10 @@ describe("dispatchTaskTool — claim resolution", () => {
   });
 
   it("Expired claim (expires_at in the past) → claim_lost", async () => {
-    // Seed a claim that's already expired by setting ttl to 0 then
-    // overriding the row.
+    // Seed a claim that's already expired by setting ttl to a negative
+    // value. We pass `nowFn` so the dispatcher's "now" comparison is
+    // deterministic against the seeded `expires_at` regardless of
+    // real wallclock.
     const { db } = seedClaim({
       endpoint: `POST ${stub!.origin}/probe`,
       ttlMs: -1000,
@@ -251,6 +253,9 @@ describe("dispatchTaskTool — claim resolution", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOK",
+      // Seeded "now" was 2026-04-29T12:00:00; expires_at = T11:59:59.
+      // Pin "now" 1 ms after the seeded clock.
+      nowFn: () => "2026-04-29T12:00:00.001Z",
     });
 
     expect(result.ok).toBe(false);
@@ -466,20 +471,19 @@ describe("dispatchTaskTool — publisher failure modes", () => {
   });
 
   it("Stub publisher hangs > timeout → publisher_timeout AND outbound socket aborted", async () => {
-    let hangResAttached = false;
-    stub!.setHandler((req, _res) => {
-      // Never call res.end; observe the request's `aborted`/`close` events
-      // to confirm the client closes the connection.
-      hangResAttached = true;
-      req.on("close", () => {
-        // No-op — we only need this listener to be registered to track
-        // that the connection actually closes.
+    // The stub never finishes the response. We listen for the request's
+    // 'close' event server-side: when the client aborts, Node emits
+    // 'close' on the IncomingMessage. That's the canonical signal that
+    // the upstream connection actually closed (vs. just the AbortController
+    // firing client-side without affecting the wire).
+    const sawServerSideClose = new Promise<void>((resolve) => {
+      stub!.setHandler((req, _res) => {
+        req.on("close", () => resolve());
       });
     });
 
     const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
 
-    const before = stub!.connections.opened;
     const result = await dispatchTaskTool({
       db,
       claimToken: "c_test",
@@ -493,15 +497,14 @@ describe("dispatchTaskTool — publisher failure modes", () => {
     if (!result.ok) {
       expect(result.errors).toContain("publisher_timeout");
     }
-    expect(hangResAttached).toBe(true);
 
-    // After the abort, the server's connection-close counter must
-    // catch up to the opened counter for THIS test's request.
-    // We give the close event a few ms to propagate.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(stub!.connections.closed).toBeGreaterThanOrEqual(
-      stub!.connections.opened - before,
-    );
+    // Server must observe the connection close as a result of the abort.
+    // Race with a 1s safety timer so a regression doesn't hang the suite.
+    const observed = await Promise.race([
+      sawServerSideClose.then(() => "closed" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 1000)),
+    ]);
+    expect(observed).toBe("closed");
   });
 
   it("Stub publisher streams > cap → publisher_response_too_large AND read aborted", async () => {
@@ -510,25 +513,28 @@ describe("dispatchTaskTool — publisher failure modes", () => {
     // until the client closes.
     let chunksWritten = 0;
     let serverEnded = false;
-    let serverClosedByClient = false;
-    stub!.setHandler((_req, res) => {
-      res.statusCode = 200;
-      res.setHeader("content-type", "application/octet-stream");
-      // Don't set content-length; chunked encoding.
-      const interval = setInterval(() => {
-        if (!res.write(Buffer.alloc(512, 0x41))) {
-          // backpressure: wait for drain.
-        }
-        chunksWritten += 1;
-        if (chunksWritten > 100) {
+    const sawServerSideClose = new Promise<void>((resolve) => {
+      stub!.setHandler((_req, res) => {
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/octet-stream");
+        // Don't set content-length; chunked encoding.
+        const interval = setInterval(() => {
+          if (res.writableEnded || res.destroyed) {
+            clearInterval(interval);
+            return;
+          }
+          res.write(Buffer.alloc(512, 0x41));
+          chunksWritten += 1;
+          if (chunksWritten > 200) {
+            clearInterval(interval);
+            serverEnded = true;
+            res.end();
+          }
+        }, 5);
+        res.on("close", () => {
           clearInterval(interval);
-          serverEnded = true;
-          res.end();
-        }
-      }, 5);
-      res.on("close", () => {
-        if (!serverEnded) serverClosedByClient = true;
-        clearInterval(interval);
+          resolve();
+        });
       });
     });
 
@@ -547,11 +553,19 @@ describe("dispatchTaskTool — publisher failure modes", () => {
     if (!result.ok) {
       expect(result.errors).toContain("publisher_response_too_large");
     }
-    // The client must have aborted before the server finished writing.
-    expect(serverClosedByClient).toBe(true);
-    // Sanity: chunks written when client cancelled is much less than full
-    // (full would be 100+).
-    expect(chunksWritten).toBeLessThan(100);
+
+    // Wait for the server-side close to fire as a result of the client
+    // aborting — proves the abort actually closed the wire connection.
+    const observed = await Promise.race([
+      sawServerSideClose.then(() => "closed" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 1000)),
+    ]);
+    expect(observed).toBe("closed");
+
+    // Sanity: chunks written when client cancelled is much less than the
+    // 200-chunk full payload — proves we aborted mid-stream.
+    expect(chunksWritten).toBeLessThan(200);
+    expect(serverEnded).toBe(false);
   });
 });
 

--- a/src/dispatch/task_tool.test.ts
+++ b/src/dispatch/task_tool.test.ts
@@ -1,0 +1,747 @@
+/**
+ * Tests for `src/dispatch/task_tool.ts` — the `task_tool` dispatcher
+ * (DESIGN.md §3.4, §3.6).
+ *
+ * Test bullets are taken verbatim from issue #12's "Verification"
+ * section. Every named bullet has at least one corresponding `it()`
+ * below; the bullet text is included in the test title.
+ *
+ * The publisher is stubbed by a real `node:http` server so we can
+ * observe socket-level behaviour (abort + close on timeout, abort +
+ * close on response cap). MSW would also work but trades some control
+ * over the stream lifetime.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+
+import type Database from "better-sqlite3";
+
+import { MurmurHeaders } from "@murmur/contracts-types";
+
+import { openDb } from "../db/index.js";
+import { runMigrations } from "../db/migrate.js";
+
+import { closeAllPools, dispatchTaskTool, poolCount } from "./task_tool.js";
+import { AUDIT_PAYLOAD_LIMIT_BYTES, truncateForAudit } from "./audit.js";
+
+/* -------------------------------------------------------------------- */
+/* Stub publisher server                                                 */
+/* -------------------------------------------------------------------- */
+
+interface StubServer {
+  readonly origin: string;
+  readonly received: Array<{
+    readonly method: string;
+    readonly path: string;
+    readonly headers: Record<string, string | string[] | undefined>;
+    readonly body: string;
+  }>;
+  /** Connections actually opened on this server. */
+  readonly connections: { readonly closed: number; readonly opened: number };
+  /** Set the next request handler. */
+  setHandler(handler: (req: IncomingMessage, res: ServerResponse) => void): void;
+  close(): Promise<void>;
+}
+
+async function startStubServer(): Promise<StubServer> {
+  const received: Array<{
+    method: string;
+    path: string;
+    headers: Record<string, string | string[] | undefined>;
+    body: string;
+  }> = [];
+  const counts = { opened: 0, closed: 0 };
+  let handler: (req: IncomingMessage, res: ServerResponse) => void = (_req, res) => {
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end("{}");
+  };
+
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (c) => {
+      body += c;
+    });
+    req.on("end", () => {
+      received.push({
+        method: req.method ?? "",
+        path: req.url ?? "",
+        headers: req.headers,
+        body,
+      });
+      handler(req, res);
+    });
+  });
+
+  server.on("connection", (sock) => {
+    counts.opened += 1;
+    sock.on("close", () => {
+      counts.closed += 1;
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as AddressInfo;
+  const origin = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    origin,
+    received,
+    connections: counts,
+    setHandler(h) {
+      handler = h;
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        // Force-disconnect any kept-alive sockets so close() resolves promptly.
+        server.closeAllConnections?.();
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+/* -------------------------------------------------------------------- */
+/* Test harness — DB seeding helpers                                     */
+/* -------------------------------------------------------------------- */
+
+interface SeededClaim {
+  readonly db: Database.Database;
+  readonly claimToken: string;
+  readonly instanceId: string;
+  readonly runId: string;
+}
+
+interface SeedOptions {
+  /** Subcommand name; default `"probe"`. */
+  readonly subcommand?: string;
+  /** Endpoint; required so the test can point at the stub origin. */
+  readonly endpoint: string;
+  /** Subcommand input schema; default `{ type: "object" }` (any object). */
+  readonly inputSchema?: Record<string, unknown>;
+  /** Status of the claim row; default `"claimed"`. */
+  readonly status?: string;
+  /** TTL — `expiresAt = now + ttlMs`; default 10 min. */
+  readonly ttlMs?: number;
+  /** Override the claim token; default `"c_test"`. */
+  readonly claimToken?: string;
+}
+
+function seedClaim(opts: SeedOptions): SeededClaim {
+  const db = openDb(":memory:");
+  runMigrations(db);
+
+  const now = "2026-04-29T12:00:00.000Z";
+  const ttl = opts.ttlMs ?? 600_000;
+  const expiresAt = new Date(Date.parse(now) + ttl).toISOString();
+  const claimToken = opts.claimToken ?? "c_test";
+
+  const def = {
+    id: "test-pipe",
+    subtasks: [
+      {
+        id: "the-subtask",
+        instructions: "do it",
+        output_schema: { type: "object" },
+        subcommands: [
+          {
+            name: opts.subcommand ?? "probe",
+            endpoint: opts.endpoint,
+            input_schema: opts.inputSchema ?? { type: "object" },
+          },
+          {
+            name: "other-subcmd",
+            endpoint: opts.endpoint,
+          },
+        ],
+      },
+    ],
+  };
+
+  db.prepare(
+    `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run("test-pipe", 1, JSON.stringify(def), now, now);
+
+  const runId = "run-1";
+  db.prepare(
+    `INSERT INTO runs (id, pipeline_id, pipeline_version, status,
+                       initial_input_json, webhook_url, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(runId, "test-pipe", 1, "running", "{}", "http://example/webhook", now);
+
+  const instanceId = "inst-1";
+  db.prepare(
+    `INSERT INTO subtask_instances
+       (id, run_id, subtask_id, status, claim_token, expires_at,
+        input_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    instanceId,
+    runId,
+    "the-subtask",
+    opts.status ?? "claimed",
+    claimToken,
+    expiresAt,
+    "{}",
+    now,
+    now,
+  );
+
+  return { db, claimToken, instanceId, runId };
+}
+
+/* -------------------------------------------------------------------- */
+/* Pooling teardown                                                      */
+/* -------------------------------------------------------------------- */
+
+let stub: StubServer | undefined;
+
+beforeEach(async () => {
+  stub = await startStubServer();
+});
+
+afterEach(async () => {
+  await closeAllPools();
+  await stub?.close();
+  stub = undefined;
+});
+
+afterAll(async () => {
+  await closeAllPools();
+});
+
+/* -------------------------------------------------------------------- */
+/* Tests                                                                 */
+/* -------------------------------------------------------------------- */
+
+describe("dispatchTaskTool — claim resolution", () => {
+  it("Unknown claim → { ok: false, errors: ['claim_lost'] }", async () => {
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_does_not_exist",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("claim_lost");
+    }
+  });
+
+  it("Expired claim (expires_at in the past) → claim_lost", async () => {
+    // Seed a claim that's already expired by setting ttl to 0 then
+    // overriding the row.
+    const { db } = seedClaim({
+      endpoint: `POST ${stub!.origin}/probe`,
+      ttlMs: -1000,
+    });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("claim_lost");
+    }
+  });
+
+  it("Done claim (status='done') → claim_lost", async () => {
+    const { db } = seedClaim({
+      endpoint: `POST ${stub!.origin}/probe`,
+      status: "done",
+    });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("claim_lost");
+    }
+  });
+});
+
+describe("dispatchTaskTool — subcommand resolution", () => {
+  it("Unknown subcommand → { ok: false, errors: ['unknown_subcommand'], data: { available: [...] } }", async () => {
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "no-such-subcmd",
+      args: {},
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("unknown_subcommand");
+    }
+    // The unknown_subcommand path also returns the available list as
+    // the `data` slot — this lets the agent self-correct without an
+    // extra round-trip.
+    expect("data" in result && result.data).toBeTruthy();
+    if ("data" in result && result.data) {
+      const avail = (result.data as { available: ReadonlyArray<string> }).available;
+      expect(avail).toContain("probe");
+      expect(avail).toContain("other-subcmd");
+    }
+  });
+});
+
+describe("dispatchTaskTool — args validation", () => {
+  it("Args fail schema → { ok: false, errors: ['validation:/foo/bar:type mismatch'] }", async () => {
+    const { db } = seedClaim({
+      endpoint: `POST ${stub!.origin}/probe`,
+      inputSchema: {
+        type: "object",
+        required: ["foo"],
+        properties: {
+          foo: {
+            type: "object",
+            required: ["bar"],
+            properties: { bar: { type: "string" } },
+          },
+        },
+      },
+    });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: { foo: { bar: 123 } },
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Ajv emits "validation:/foo/bar:must be string" — assert the
+      // shape, not the exact wording (Ajv version drift).
+      expect(
+        result.errors.some(
+          (e) => typeof e === "string" && e.startsWith("validation:/foo/bar:"),
+        ),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("dispatchTaskTool — proxy success path", () => {
+  it("Stub publisher 200 → forwarded body in data", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ ok: true, postings_seen: 42 }));
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: { board_url: "https://example.com" },
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ ok: true, postings_seen: 42 });
+    }
+  });
+
+  it("Bearer header included in proxy request", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end("{}");
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOKEN_VALUE",
+    });
+
+    expect(stub!.received[0]?.headers.authorization).toBe("Bearer TOKEN_VALUE");
+  });
+
+  it("X-Murmur-Subcommand and X-Murmur-Claim-Token headers present on proxy request", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end("{}");
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+    });
+
+    const headers = stub!.received[0]!.headers;
+    expect(headers[MurmurHeaders.X_MURMUR_SUBCOMMAND.toLowerCase()]).toBe(
+      "probe",
+    );
+    expect(headers[MurmurHeaders.X_MURMUR_CLAIM_TOKEN.toLowerCase()]).toBe(
+      "c_test",
+    );
+  });
+
+  it("forwards the agent's args as the JSON body", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end("{}");
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: { board_url: "https://example.com", token: "abc" },
+      bearer: "TOK",
+    });
+
+    const body = stub!.received[0]!.body;
+    expect(JSON.parse(body)).toEqual({
+      board_url: "https://example.com",
+      token: "abc",
+    });
+  });
+});
+
+describe("dispatchTaskTool — publisher failure modes", () => {
+  it("Stub publisher 5xx → { ok: false, errors: ['publisher_5xx', '503'] }", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 503;
+      res.end("upstream broken");
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("publisher_5xx");
+      expect(result.errors).toContain("503");
+    }
+  });
+
+  it("Stub publisher hangs > timeout → publisher_timeout AND outbound socket aborted", async () => {
+    let hangResAttached = false;
+    stub!.setHandler((req, _res) => {
+      // Never call res.end; observe the request's `aborted`/`close` events
+      // to confirm the client closes the connection.
+      hangResAttached = true;
+      req.on("close", () => {
+        // No-op — we only need this listener to be registered to track
+        // that the connection actually closes.
+      });
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const before = stub!.connections.opened;
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+      timeoutMs: 100,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("publisher_timeout");
+    }
+    expect(hangResAttached).toBe(true);
+
+    // After the abort, the server's connection-close counter must
+    // catch up to the opened counter for THIS test's request.
+    // We give the close event a few ms to propagate.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stub!.connections.closed).toBeGreaterThanOrEqual(
+      stub!.connections.opened - before,
+    );
+  });
+
+  it("Stub publisher streams > cap → publisher_response_too_large AND read aborted", async () => {
+    // Stream a body larger than `responseCapBytes`. We use a small cap
+    // (2 KB) so the test runs fast. Server flushes 512-byte chunks
+    // until the client closes.
+    let chunksWritten = 0;
+    let serverEnded = false;
+    let serverClosedByClient = false;
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/octet-stream");
+      // Don't set content-length; chunked encoding.
+      const interval = setInterval(() => {
+        if (!res.write(Buffer.alloc(512, 0x41))) {
+          // backpressure: wait for drain.
+        }
+        chunksWritten += 1;
+        if (chunksWritten > 100) {
+          clearInterval(interval);
+          serverEnded = true;
+          res.end();
+        }
+      }, 5);
+      res.on("close", () => {
+        if (!serverEnded) serverClosedByClient = true;
+        clearInterval(interval);
+      });
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const result = await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: {},
+      bearer: "TOK",
+      responseCapBytes: 2 * 1024,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toContain("publisher_response_too_large");
+    }
+    // The client must have aborted before the server finished writing.
+    expect(serverClosedByClient).toBe(true);
+    // Sanity: chunks written when client cancelled is much less than full
+    // (full would be 100+).
+    expect(chunksWritten).toBeLessThan(100);
+  });
+});
+
+describe("dispatchTaskTool — audit log", () => {
+  it("each call writes one row to agent_actions with truncated args_json and response_json", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ result: "x" }));
+    });
+
+    const { db, instanceId } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: { kind: "small" },
+      bearer: "TOK",
+    });
+
+    const rows = db
+      .prepare(
+        `SELECT instance_id, kind, subcommand, args_json, response_json, truncated
+           FROM agent_actions
+          WHERE kind = 'task_tool'`,
+      )
+      .all() as Array<{
+      instance_id: string;
+      kind: string;
+      subcommand: string | null;
+      args_json: string | null;
+      response_json: string | null;
+      truncated: number;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    const r = rows[0]!;
+    expect(r.instance_id).toBe(instanceId);
+    expect(r.kind).toBe("task_tool");
+    expect(r.subcommand).toBe("probe");
+    expect(r.args_json).toBeTruthy();
+    expect(r.response_json).toBeTruthy();
+    expect(JSON.parse(r.args_json!)).toEqual({ kind: "small" });
+    expect(JSON.parse(r.response_json!)).toEqual({ result: "x" });
+    expect(r.truncated).toBe(0);
+  });
+
+  it("oversize args_json and response_json are truncated to 4 KB and the row is flagged", async () => {
+    // 8 KB response.
+    const big = "X".repeat(8 * 1024);
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ blob: big }));
+    });
+
+    const { db } = seedClaim({
+      endpoint: `POST ${stub!.origin}/probe`,
+      // No input schema → 8 KB args pass through unvalidated.
+    });
+
+    const args = { blob: big };
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args,
+      bearer: "TOK",
+    });
+
+    const r = db
+      .prepare(
+        `SELECT args_json, response_json, truncated FROM agent_actions WHERE kind='task_tool'`,
+      )
+      .get() as {
+      args_json: string;
+      response_json: string;
+      truncated: number;
+    };
+    expect(Buffer.byteLength(r.args_json, "utf8")).toBeLessThanOrEqual(
+      AUDIT_PAYLOAD_LIMIT_BYTES,
+    );
+    expect(Buffer.byteLength(r.response_json, "utf8")).toBeLessThanOrEqual(
+      AUDIT_PAYLOAD_LIMIT_BYTES,
+    );
+    expect(r.truncated).toBe(1);
+  });
+
+  it("audit row is also written on publisher 5xx (so operators can diagnose)", async () => {
+    stub!.setHandler((_req, res) => {
+      res.statusCode = 503;
+      res.end("oops");
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    await dispatchTaskTool({
+      db,
+      claimToken: "c_test",
+      subcommand: "probe",
+      args: { x: 1 },
+      bearer: "TOK",
+    });
+
+    const rows = db
+      .prepare(
+        `SELECT response_json FROM agent_actions WHERE kind='task_tool'`,
+      )
+      .all() as Array<{ response_json: string }>;
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe("dispatchTaskTool — connection pooling", () => {
+  it("100 concurrent calls resolve and don't blow open 100 sockets", async () => {
+    let inflight = 0;
+    let peakInflight = 0;
+    stub!.setHandler((_req, res) => {
+      inflight += 1;
+      peakInflight = Math.max(peakInflight, inflight);
+      // Tiny delay so concurrency is observable.
+      setTimeout(() => {
+        inflight -= 1;
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end("{}");
+      }, 10);
+    });
+
+    const { db } = seedClaim({ endpoint: `POST ${stub!.origin}/probe` });
+
+    const calls = Array.from({ length: 100 }, () =>
+      dispatchTaskTool({
+        db,
+        claimToken: "c_test",
+        subcommand: "probe",
+        args: {},
+        bearer: "TOK",
+      }),
+    );
+
+    const results = await Promise.all(calls);
+    expect(results.every((r) => r.ok)).toBe(true);
+
+    // Hard cap is 50 per origin per the issue's quality gate. With 100
+    // concurrent calls the peak in-flight at the publisher must be ≤ 50.
+    expect(peakInflight).toBeLessThanOrEqual(50);
+
+    // Pool cache should have exactly one entry — one origin reused.
+    expect(poolCount()).toBe(1);
+
+    // After all are done, give sockets a tick to settle then ensure
+    // server has closed at least as many as it opened minus the
+    // keep-alive idles still open inside the pool.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(stub!.connections.opened).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("truncateForAudit", () => {
+  it("returns null for null input", () => {
+    expect(truncateForAudit(null)).toEqual({ text: null, truncated: false });
+  });
+
+  it("returns input unchanged when within cap", () => {
+    const r = truncateForAudit("hello");
+    expect(r).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("clips inputs above cap and flags truncated", () => {
+    const big = "X".repeat(AUDIT_PAYLOAD_LIMIT_BYTES + 100);
+    const r = truncateForAudit(big);
+    expect(r.truncated).toBe(true);
+    expect(r.text).not.toBeNull();
+    expect(Buffer.byteLength(r.text!, "utf8")).toBeLessThanOrEqual(
+      AUDIT_PAYLOAD_LIMIT_BYTES,
+    );
+  });
+
+  it("clips on a UTF-8 boundary (no half-character at the cut)", () => {
+    // Build a string of 4-byte UTF-8 characters (an emoji) such that
+    // the byte cap falls in the middle of one.
+    const emoji = "\u{1F600}"; // 4 bytes in UTF-8
+    const count = Math.floor(AUDIT_PAYLOAD_LIMIT_BYTES / 4) + 5;
+    const big = emoji.repeat(count);
+    const r = truncateForAudit(big);
+    expect(r.truncated).toBe(true);
+    expect(r.text).not.toBeNull();
+    // The clipped text should be valid UTF-8 with no replacement char.
+    expect(r.text).not.toMatch(/�/);
+  });
+});

--- a/src/dispatch/task_tool.ts
+++ b/src/dispatch/task_tool.ts
@@ -51,9 +51,13 @@
  */
 
 import type Database from "better-sqlite3";
-import type { Pool } from "undici";
+import { Pool } from "undici";
 
-import type { EnvelopeResponse } from "@murmur/contracts-types";
+import type { EnvelopeResponse, Err, Ok } from "@murmur/contracts-types";
+import { MurmurHeaders } from "@murmur/contracts-types";
+
+import { truncateForAudit } from "./audit.js";
+import { validateAgainst } from "./validation.js";
 
 /**
  * Options accepted by {@link dispatchTaskTool}.
@@ -142,7 +146,116 @@ export interface UnknownSubcommandData {
 export async function dispatchTaskTool(
   options: DispatchTaskToolOptions,
 ): Promise<EnvelopeResponse<DispatchSuccessData | UnknownSubcommandData>> {
-  throw new Error("not implemented");
+  const {
+    db,
+    claimToken,
+    subcommand,
+    args,
+    bearer,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    responseCapBytes = DEFAULT_RESPONSE_CAP_BYTES,
+    nowFn = defaultNowFn,
+    poolFactory,
+  } = options;
+
+  /* 1. Resolve claim. */
+  const now = nowFn();
+  const claim = lookupClaim(db, claimToken, now);
+  if (claim === null) {
+    const body: Err = { ok: false, errors: ["claim_lost"] };
+    return body;
+  }
+
+  /* 2. Locate subcommand in the active subtask def. */
+  const def = parsePipelineDef(claim.def_json);
+  if (def === null) {
+    // Pipeline def unparseable. Surface as a stable failure.
+    return { ok: false, errors: ["pipeline_not_found"] };
+  }
+  const subtask = def.subtasks.find((s) => s.id === claim.subtask_id);
+  if (subtask === undefined) {
+    return { ok: false, errors: ["pipeline_not_found"] };
+  }
+  const subcmds = subtask.subcommands ?? [];
+  const subcmd = subcmds.find((s) => s.name === subcommand);
+  if (subcmd === undefined) {
+    const data: UnknownSubcommandData = {
+      available: subcmds.map((s) => s.name),
+    };
+    return {
+      ok: false,
+      errors: ["unknown_subcommand"],
+      // The envelope contract permits `data` only on `Ok`. We emit the
+      // available list as part of the error envelope by attaching it
+      // under a typed cast. The MCP/HTTP shim handles serialisation.
+      // (See the issue's "Unknown subcommand" verification for the
+      // exact wire shape.)
+      ...({ data } as { data: UnknownSubcommandData }),
+    } as Err & { data: UnknownSubcommandData };
+  }
+
+  /* 3. Validate args against input_schema (if declared). */
+  if (subcmd.input_schema !== undefined) {
+    const v = validateAgainst(subcmd.input_schema, args);
+    if (!v.ok) {
+      // No audit row for validation failures: the call never left the
+      // server, the publisher is uninvolved, and the agent's args are
+      // already echoed to it via the error response. Adds noise, no signal.
+      return { ok: false, errors: v.errors };
+    }
+  }
+
+  /* 4. Build the proxy request. */
+  const parsed = parseEndpoint(subcmd.endpoint);
+  if (parsed === null) {
+    return { ok: false, errors: ["pipeline_not_found"] };
+  }
+
+  const pool = (poolFactory ?? defaultPoolFactory)(parsed.origin);
+
+  /* 5. POST with timeout + cap. */
+  const argsJson = safeStringify(args);
+  const httpResult = await proxyToPublisher({
+    pool,
+    path: parsed.pathname,
+    method: parsed.method,
+    bearer,
+    subcommand,
+    claimToken,
+    body: argsJson,
+    timeoutMs,
+    responseCapBytes,
+  });
+
+  /* 6. Audit. Write one row regardless of outcome. */
+  const auditArgs = truncateForAudit(argsJson);
+  const auditResp = truncateForAudit(httpResult.responseJson ?? null);
+  const truncated = auditArgs.truncated || auditResp.truncated ? 1 : 0;
+  try {
+    db.prepare(
+      `INSERT INTO agent_actions
+         (instance_id, ts, kind, subcommand, args_json, response_json, truncated)
+       VALUES (?, ?, 'task_tool', ?, ?, ?, ?)`,
+    ).run(
+      claim.instance_id,
+      nowFn(),
+      subcommand,
+      auditArgs.text,
+      auditResp.text,
+      truncated,
+    );
+  } catch {
+    // Audit failure must not mask the dispatch result. The DB error
+    // surfaces via the migrations test path; in production a missing
+    // audit row is recoverable, a missing dispatch reply is not.
+  }
+
+  /* 7. Translate the HTTP outcome into the envelope. */
+  if (httpResult.kind === "ok") {
+    const body: Ok<DispatchSuccessData> = { ok: true, data: httpResult.data };
+    return body;
+  }
+  return { ok: false, errors: httpResult.errors };
 }
 
 /**
@@ -154,7 +267,9 @@ export async function dispatchTaskTool(
  *          completed.
  */
 export async function closeAllPools(): Promise<void> {
-  throw new Error("not implemented");
+  const pools = Array.from(pools_.values());
+  pools_.clear();
+  await Promise.all(pools.map((p) => p.close()));
 }
 
 /**
@@ -162,5 +277,324 @@ export async function closeAllPools(): Promise<void> {
  * the module-scoped cache is being reused rather than churned.
  */
 export function poolCount(): number {
-  throw new Error("not implemented");
+  return pools_.size;
+}
+
+/* --------------------------------------------------------------------
+ * Internals
+ * -------------------------------------------------------------------- */
+
+/** Default 15s timeout per DESIGN.md §3.6. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** Default 1 MB response cap per DESIGN.md §3.6. */
+const DEFAULT_RESPONSE_CAP_BYTES = 1_048_576;
+
+/**
+ * Per-origin connection cap. The issue's quality gate calls for a hard
+ * limit (e.g., 50 concurrent). 50 is also undici's default for `Pool`
+ * but we set it explicitly so a future undici default change cannot
+ * silently weaken the cap.
+ */
+const POOL_CONNECTIONS_PER_ORIGIN = 50;
+
+/** Module-scoped cache: one undici Pool per origin. Reused across calls. */
+const pools_: Map<string, Pool> = new Map();
+
+function defaultPoolFactory(origin: string): Pool {
+  let pool = pools_.get(origin);
+  if (pool === undefined) {
+    pool = new Pool(origin, {
+      connections: POOL_CONNECTIONS_PER_ORIGIN,
+      pipelining: 1,
+      // Keep-alive defaults are fine; we want sockets reused.
+    });
+    pools_.set(origin, pool);
+  }
+  return pool;
+}
+
+function defaultNowFn(): string {
+  return new Date().toISOString();
+}
+
+/* ---------------- Claim lookup ---------------- */
+
+interface ResolvedClaim {
+  readonly instance_id: string;
+  readonly subtask_id: string;
+  readonly def_json: string;
+}
+
+const LOOKUP_CLAIM_SQL = `
+  SELECT subtask_instances.id          AS instance_id,
+         subtask_instances.subtask_id  AS subtask_id,
+         pipelines.def_json            AS def_json
+    FROM subtask_instances
+    JOIN runs      ON runs.id          = subtask_instances.run_id
+    JOIN pipelines ON pipelines.id     = runs.pipeline_id
+   WHERE subtask_instances.claim_token = ?
+     AND subtask_instances.status      = 'claimed'
+     AND subtask_instances.expires_at  > ?
+`;
+
+function lookupClaim(
+  db: Database.Database,
+  claimToken: string,
+  nowIso: string,
+): ResolvedClaim | null {
+  const row = db.prepare(LOOKUP_CLAIM_SQL).get(claimToken, nowIso) as
+    | { instance_id: string; subtask_id: string; def_json: string }
+    | undefined;
+  if (row === undefined) return null;
+  return {
+    instance_id: row.instance_id,
+    subtask_id: row.subtask_id,
+    def_json: row.def_json,
+  };
+}
+
+/* ---------------- Pipeline def cache ---------------- */
+
+interface CachedSubcommandDef {
+  readonly name: string;
+  readonly endpoint: string;
+  readonly input_schema?: Record<string, unknown>;
+}
+
+interface CachedSubtaskDef {
+  readonly id: string;
+  readonly subcommands?: ReadonlyArray<CachedSubcommandDef>;
+}
+
+interface CachedPipelineDef {
+  readonly subtasks: ReadonlyArray<CachedSubtaskDef>;
+}
+
+/**
+ * Cache parsed pipeline defs by the raw `def_json` string. Identical
+ * strings (the common case for repeated calls on the same pipeline
+ * version) hit the cache; on def upsert the string changes and the
+ * old entry is replaced. Bounded by `DEF_CACHE_LIMIT` LRU entries to
+ * avoid unbounded growth in pathological deployments.
+ */
+const DEF_CACHE_LIMIT = 32;
+const defCache: Map<string, CachedPipelineDef | null> = new Map();
+
+function parsePipelineDef(defJson: string): CachedPipelineDef | null {
+  const cached = defCache.get(defJson);
+  if (cached !== undefined) {
+    // Refresh LRU position.
+    defCache.delete(defJson);
+    defCache.set(defJson, cached);
+    return cached;
+  }
+  let parsed: CachedPipelineDef | null;
+  try {
+    parsed = JSON.parse(defJson) as CachedPipelineDef;
+  } catch {
+    parsed = null;
+  }
+  // LRU eviction.
+  if (defCache.size >= DEF_CACHE_LIMIT) {
+    const oldest = defCache.keys().next().value;
+    if (oldest !== undefined) defCache.delete(oldest);
+  }
+  defCache.set(defJson, parsed);
+  return parsed;
+}
+
+/* ---------------- Endpoint parsing ---------------- */
+
+interface ParsedEndpoint {
+  readonly method: string;
+  readonly origin: string;
+  readonly pathname: string;
+}
+
+/**
+ * Parse the pipeline-def `endpoint` string. DESIGN.md §3.1 uses the
+ * "METHOD URL" form (e.g. `"POST https://example.com/path"`). We're
+ * generous and accept a bare URL with an implied POST, since §3.4 only
+ * speaks of a POST proxy.
+ */
+function parseEndpoint(endpoint: string): ParsedEndpoint | null {
+  const trimmed = endpoint.trim();
+  let method = "POST";
+  let urlPart = trimmed;
+
+  const space = trimmed.indexOf(" ");
+  if (space > 0) {
+    const head = trimmed.slice(0, space);
+    if (/^[A-Za-z]+$/.test(head)) {
+      method = head.toUpperCase();
+      urlPart = trimmed.slice(space + 1).trim();
+    }
+  }
+
+  let url: URL;
+  try {
+    url = new URL(urlPart);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  return {
+    method,
+    origin: `${url.protocol}//${url.host}`,
+    pathname: `${url.pathname}${url.search}`,
+  };
+}
+
+/* ---------------- HTTP proxy ---------------- */
+
+interface ProxyOk {
+  readonly kind: "ok";
+  readonly data: unknown;
+  readonly responseJson: string;
+}
+
+interface ProxyErr {
+  readonly kind: "err";
+  readonly errors: ReadonlyArray<string>;
+  readonly responseJson?: string;
+}
+
+interface ProxyOptions {
+  readonly pool: Pool;
+  readonly path: string;
+  readonly method: string;
+  readonly bearer: string;
+  readonly subcommand: string;
+  readonly claimToken: string;
+  readonly body: string;
+  readonly timeoutMs: number;
+  readonly responseCapBytes: number;
+}
+
+async function proxyToPublisher(
+  opts: ProxyOptions,
+): Promise<ProxyOk | ProxyErr> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
+  // `unref` so a pending timer never blocks process exit.
+  if (typeof (timer as unknown as { unref?: () => void }).unref === "function") {
+    (timer as unknown as { unref: () => void }).unref();
+  }
+
+  let res;
+  try {
+    res = await opts.pool.request({
+      method: opts.method as
+        | "GET"
+        | "POST"
+        | "PUT"
+        | "PATCH"
+        | "DELETE"
+        | "HEAD"
+        | "OPTIONS",
+      path: opts.path,
+      headers: {
+        [MurmurHeaders.AUTHORIZATION]: `Bearer ${opts.bearer}`,
+        [MurmurHeaders.X_MURMUR_SUBCOMMAND]: opts.subcommand,
+        [MurmurHeaders.X_MURMUR_CLAIM_TOKEN]: opts.claimToken,
+        "content-type": "application/json",
+      },
+      body: opts.body,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    if (isAbortError(err) || controller.signal.aborted) {
+      return { kind: "err", errors: ["publisher_timeout"] };
+    }
+    return { kind: "err", errors: ["publisher_unreachable"] };
+  }
+
+  // Headers are in. Stream-read the body with a hard byte cap, never
+  // touching `res.body.text()` (which would buffer the whole thing).
+  const status = res.statusCode;
+  const reader = res.body;
+  let total = 0;
+  const chunks: Buffer[] = [];
+  let tooLarge = false;
+
+  try {
+    for await (const chunk of reader) {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buf.byteLength;
+      if (total > opts.responseCapBytes) {
+        tooLarge = true;
+        // Abort the request — undici closes the underlying socket so we
+        // don't keep the upstream sender writing into the void.
+        controller.abort();
+        // Drain whatever's left so undici can recycle the socket.
+        // (Iteration breaks below; the abort already terminated the
+        // server side per the test assertion.)
+        break;
+      }
+      chunks.push(buf);
+    }
+  } catch (err) {
+    clearTimeout(timer);
+    if (isAbortError(err) || controller.signal.aborted) {
+      // Could be timeout-mid-body OR our cap-induced abort. The
+      // tooLarge flag disambiguates.
+      if (tooLarge) {
+        return { kind: "err", errors: ["publisher_response_too_large"] };
+      }
+      return { kind: "err", errors: ["publisher_timeout"] };
+    }
+    return { kind: "err", errors: ["publisher_unreachable"] };
+  }
+  clearTimeout(timer);
+
+  if (tooLarge) {
+    return { kind: "err", errors: ["publisher_response_too_large"] };
+  }
+
+  const responseJson = Buffer.concat(chunks).toString("utf8");
+
+  if (status >= 500) {
+    return {
+      kind: "err",
+      errors: ["publisher_5xx", String(status)],
+      responseJson,
+    };
+  }
+  if (status >= 400) {
+    return {
+      kind: "err",
+      errors: ["publisher_4xx", String(status)],
+      responseJson,
+    };
+  }
+
+  // Success: parse JSON if possible; fall back to the raw string.
+  let parsed: unknown;
+  try {
+    parsed = responseJson.length === 0 ? null : JSON.parse(responseJson);
+  } catch {
+    parsed = responseJson;
+  }
+  return { kind: "ok", data: parsed, responseJson };
+}
+
+function isAbortError(err: unknown): boolean {
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return true;
+    if ("code" in err && (err as { code?: string }).code === "UND_ERR_ABORTED") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return '"<unserializable>"';
+  }
 }

--- a/src/dispatch/task_tool.ts
+++ b/src/dispatch/task_tool.ts
@@ -1,0 +1,166 @@
+/**
+ * `task_tool(subcommand, claim, args)` dispatcher (DESIGN.md §3.4, §3.6).
+ *
+ * Pure function — no HTTP route is registered here. The MCP `task_tool`
+ * handler (M6) and any future HTTP shim call {@link dispatchTaskTool}.
+ *
+ * The dispatcher walks the following pipeline, folding every failure
+ * into the M0 `EnvelopeResponse` shape:
+ *
+ *   1. **Resolve claim.** Look up `subtask_instances` by `claim_token`,
+ *      joined to `runs` and `pipelines`. If unknown, expired, or status
+ *      is anything other than `claimed` → `claim_lost`.
+ *   2. **Locate subcommand.** Find the subtask def in the pipeline def
+ *      whose `id` matches the claim's `subtask_id`; search its
+ *      `subcommands[]` for `name === subcommand`. If the subtask itself
+ *      has no `subcommands`, or the name is missing →
+ *      `unknown_subcommand` with `data.available: string[]`.
+ *   3. **Validate args.** Run `validateAgainst(input_schema, args)` from
+ *      M9. Fail → return the Ajv `validation:<path>:<msg>` strings.
+ *      No `input_schema` declared on the subcommand → args are passed
+ *      through unvalidated (subcommand author opted out).
+ *   4. **Build the proxy request.** Bearer auth, `X-Murmur-Subcommand`,
+ *      `X-Murmur-Claim-Token` headers (constants from
+ *      `@murmur/contracts-types`). Method + URL parsed from the
+ *      subcommand's `endpoint` ("METHOD URL" form).
+ *   5. **POST with timeout + cap.** 15s `AbortController` timeout. Read
+ *      the body chunk-by-chunk and abort at 1 MB. The HTTP client is
+ *      `undici`'s `Pool` per origin with `connections: 50` cap, kept in
+ *      a module-scoped `Map` so a flood of concurrent calls reuses
+ *      sockets rather than opening one per call.
+ *   6. **Audit.** One `agent_actions` row per call (kind=`task_tool`),
+ *      with `args_json` + `response_json` truncated to 4 KB. Audit is
+ *      written even for failure paths so operators can diagnose.
+ *
+ * **Concurrency note.** `dispatchTaskTool` is `async`, but every DB
+ * read it issues is synchronous (better-sqlite3). The DB is touched
+ * once at the start (claim + def lookup) and once at the end (audit
+ * insert). The HTTP round-trip is the only part that yields. Two
+ * concurrent calls on the same claim are serialised by the better-
+ * sqlite3 connection mutex on the audit insert; that's the only
+ * shared mutable state between calls.
+ *
+ * **No mid-flight TTL slide for MVP.** DESIGN.md §3.3 lists a sliding
+ * TTL on success as "Reinstated for full ws coverage" — we don't update
+ * `expires_at` here. A 14s probe + 10s claim TTL means a probe can
+ * outlive its claim; that's the documented tradeoff for the demo.
+ *
+ * @see DESIGN.md §3.4 — Dispatch
+ * @see DESIGN.md §3.6 — Failure modes (publisher_timeout, publisher_5xx,
+ *                       publisher_response_too_large)
+ */
+
+import type Database from "better-sqlite3";
+import type { Pool } from "undici";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+/**
+ * Options accepted by {@link dispatchTaskTool}.
+ *
+ * Most fields are seams for testing. Production callers (the MCP
+ * `task_tool` handler) supply only `db`, `claimToken`, `subcommand`,
+ * `args`, `bearer`.
+ */
+export interface DispatchTaskToolOptions {
+  /** Open better-sqlite3 connection. The dispatcher does not own its lifecycle. */
+  readonly db: Database.Database;
+  /** The `claim` value the agent received from `pull_task`. */
+  readonly claimToken: string;
+  /** The subcommand name the agent invoked (e.g. `"probe monitor"`). */
+  readonly subcommand: string;
+  /** The agent-supplied args. Not validated by the dispatcher beyond the schema check. */
+  readonly args: unknown;
+  /**
+   * The `MURMUR_TOKEN` value that gates Murmur's own endpoints. Murmur
+   * forwards the SAME token to the publisher per DESIGN.md §3.6
+   * (single-bearer model for the demo). Caller MUST supply; the
+   * dispatcher does not read `process.env`.
+   */
+  readonly bearer: string;
+  /**
+   * Override the per-call timeout. Default 15_000 ms (DESIGN.md §3.6).
+   * Tests use small values (e.g. 100ms) to exercise the timeout path
+   * without sleeping.
+   */
+  readonly timeoutMs?: number;
+  /**
+   * Override the response body cap. Default 1_048_576 bytes (1 MB).
+   * Tests use small values to exercise the cap path quickly.
+   */
+  readonly responseCapBytes?: number;
+  /**
+   * Override the now() function for deterministic audit timestamps.
+   * Default `() => new Date().toISOString()`.
+   */
+  readonly nowFn?: () => string;
+  /**
+   * Override the pool factory for tests. Production uses the
+   * module-scoped `Map<origin, Pool>` cache.
+   */
+  readonly poolFactory?: (origin: string) => Pool;
+}
+
+/**
+ * Successful proxy response. The publisher's parsed JSON body is
+ * surfaced verbatim under `data`. If the publisher returns a non-JSON
+ * body but a 2xx status, `data` is the raw string; this is acceptable
+ * for the demo (publishers in scope return JSON).
+ */
+export type DispatchSuccessData = unknown;
+
+/**
+ * Body shape attached to `unknown_subcommand` failures so the agent
+ * can self-correct without a round-trip.
+ */
+export interface UnknownSubcommandData {
+  readonly available: ReadonlyArray<string>;
+}
+
+/**
+ * Dispatch a `task_tool` invocation. Folds every failure into the
+ * `EnvelopeResponse` shape — never throws. The error tokens used are
+ * stable across MVP and post-MVP:
+ *
+ *   - `claim_lost`               — claim unknown / expired / status≠claimed.
+ *   - `unknown_subcommand`       — name not in the subtask's `subcommands[]`.
+ *                                  `data.available: string[]` lists valid names.
+ *   - `validation:<path>:<msg>`  — args fail `input_schema` (one entry per
+ *                                  Ajv error; `validateAgainst` formats them).
+ *   - `publisher_timeout`        — 15s elapsed before headers. Outbound
+ *                                  socket aborted via `AbortController`.
+ *   - `publisher_5xx` + `<code>` — publisher returned 5xx. Both tokens
+ *                                  appear in `errors`, in that order.
+ *   - `publisher_response_too_large` — response body exceeded 1 MB.
+ *                                      Read aborted; pool socket released.
+ *   - `publisher_unreachable`    — DNS/connect/TLS error. Catch-all for
+ *                                  network-level failures distinct from
+ *                                  the above.
+ *
+ * @returns an `EnvelopeResponse` ready for serialisation by the caller.
+ */
+export async function dispatchTaskTool(
+  options: DispatchTaskToolOptions,
+): Promise<EnvelopeResponse<DispatchSuccessData | UnknownSubcommandData>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Tear down every cached pool. Tests call this in `afterEach`/`afterAll`
+ * to ensure no socket leaks across test cases. Production has no need
+ * to call this — the pools live for the process lifetime.
+ *
+ * @returns a promise that resolves when every pool's `close()` has
+ *          completed.
+ */
+export async function closeAllPools(): Promise<void> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Inspect the count of cached pools. Tests use this to assert that
+ * the module-scoped cache is being reused rather than churned.
+ */
+export function poolCount(): number {
+  throw new Error("not implemented");
+}


### PR DESCRIPTION
## Summary
Implements `dispatchTaskTool({ db, claimToken, subcommand, args, bearer })` — the `task_tool` dispatcher per DESIGN.md §3.4 / §3.6. Resolves the claim via SQL join (`subtask_instances` × `runs` × `pipelines.def_json`), validates `args` against the active subtask's subcommand `input_schema` via M9's `validateAgainst`, and proxies to the publisher's `endpoint` over `undici.Pool` with a 15s `AbortController` timeout, a 1 MB streaming-read response cap, and bearer + `X-Murmur-Subcommand` + `X-Murmur-Claim-Token` headers. Audit row written to `agent_actions` per call with 4 KB UTF-8-safe truncation on `args_json` + `response_json`.

The dispatcher is a pure function — no HTTP route is registered in this PR. M6 (MCP server) will call it from the `task_tool` MCP tool handler.

## Related issue
Closes colophon-group/murmur#12

## Files changed (high-level)
- `src/dispatch/task_tool.ts` — `dispatchTaskTool`, module-scoped per-origin `undici.Pool` cache (50 conns/origin), `parseEndpoint("METHOD URL")`, `lookupClaim` (SQL join), per-`def_json` LRU pipeline-def parse cache, `proxyToPublisher` with `AbortController` and chunk-by-chunk byte cap.
- `src/dispatch/audit.ts` — `truncateForAudit(json | null)` UTF-8-safe truncation at 4 KB. Why a separate file from M9's `validation.ts`: orchestrator note for #12 instructs not to modify `validation.ts`.
- `src/dispatch/task_tool.test.ts` — 20 tests using a real `node:http` stub server so we can observe actual TCP-level abort behaviour (server-side `'close'` event after client abort).
- `package.json` + `pnpm-lock.yaml` — adds `undici@^7.6.0` (Node has it bundled for global `fetch`, but the stand-alone import is what gives us configurable `Pool`).

## Verification (from the issue)
- [x] Unknown claim → `{ ok: false, errors: ["claim_lost"] }`
- [x] Unknown subcommand → `{ ok: false, errors: ["unknown_subcommand"], data: { available: [...] } }`
- [x] Args fail schema → `{ ok: false, errors: ["validation:/foo/bar:..."] }`
- [x] Stub publisher 200 → forwarded body in `data`
- [x] Stub publisher 5xx → `{ ok: false, errors: ["publisher_5xx", "503"] }`
- [x] Stub publisher hangs > timeout → `publisher_timeout` AND server-side request `'close'` observed (proves wire-level abort)
- [x] Stub publisher streams > cap → `publisher_response_too_large` AND read aborted before the server finishes its 200-chunk payload (`serverEnded === false`)
- [x] Bearer header included on proxy request
- [x] `X-Murmur-Subcommand` and `X-Murmur-Claim-Token` headers present
- [x] Each call writes one row to `agent_actions` with truncated `args_json` and `response_json`
- [x] 100 concurrent `task_tool` calls don't leak sockets — peak in-flight at the publisher ≤ 50, exactly one pool reused for all 100

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (174 tests pass; coverage on `src/dispatch/**` aggregate: lines 88.48%, branches 76.11% — both above the 85/75 gate)
- `pnpm grep:all` ✓ (4 grep gates pass)
- `pnpm build` ✓
- 100-concurrent leak test: peak in-flight 50/100, `poolCount() === 1`

## Notes for reviewer
- **Endpoint parsing.** §3.1 uses `"POST <url>"` format. `parseEndpoint` accepts that AND a bare URL (defaults to `POST`). Rejects non-http(s) schemes.
- **Pipeline-def cache.** Keyed by raw `def_json` string; an upsert changes the string and the entry is replaced. LRU bound at 32 to cap memory in pathological cases. No version-pinning per claim — DESIGN.md §3.3 explicitly says "schemas and endpoint URLs are read live" for MVP.
- **No mid-flight TTL slide.** §3.3 lists sliding TTL on success as "Reinstated for full ws coverage" — not in this PR.
- **Audit on validation failure: skipped.** A schema-failed `task_tool` call never leaves the server; the publisher is uninvolved and the agent already sees the errors in the response. Documented inline.
- **Audit on publisher 5xx/timeout/cap: written.** Operators need these for diagnosis. Test covers the 5xx path.
- **Where the `data: {available}` lands on the unknown_subcommand failure:** the M0 `Err` envelope formally only has `errors[]`. We attach `data: {available}` via a typed cast, matching the issue's verification spec verbatim. The cast is documented inline; if the reviewer prefers a separate envelope shape, easy follow-up.
- **`undici` version pinning:** `^7.6.0`; pnpm resolved 7.25.0. Node 22 ships undici as a built-in but doesn't expose `Pool` from the bundled copy via `import "undici"`, so the explicit dep is required.