### PR TITLE
fix(dispatch): inject nowFn into task_tool to deflake tests

### DIFF
--- a/src/dispatch/task_tool.test.ts
+++ b/src/dispatch/task_tool.test.ts
@@ -109,6 +109,18 @@ async function startStubServer(): Promise<StubServer> {
 /* Test harness — DB seeding helpers                                     */
 /* -------------------------------------------------------------------- */
 
+/**
+ * Pinned "now" for the seeded fixture. The dispatcher uses `nowFn` for
+ * both the `expires_at > ?` filter in the claim-resolution SQL and the
+ * `agent_actions.ts` audit timestamp; if the test relies on the real
+ * wall clock instead, every test that seeds the default 10-min TTL
+ * fails as soon as the wall clock advances past `SEEDED_NOW + 10min`
+ * (i.e. always, in CI). Pin a deterministic "now" inside the seeded
+ * TTL window for every dispatch call.
+ */
+const SEEDED_NOW = "2026-04-29T12:00:00.000Z";
+const seededNowFn = (): string => SEEDED_NOW;
+
 interface SeededClaim {
   readonly db: Database.Database;
   readonly claimToken: string;
@@ -135,7 +147,7 @@ function seedClaim(opts: SeedOptions): SeededClaim {
   const db = openDb(":memory:");
   runMigrations(db);
 
-  const now = "2026-04-29T12:00:00.000Z";
+  const now = SEEDED_NOW;
   const ttl = opts.ttlMs ?? 600_000;
   const expiresAt = new Date(Date.parse(now) + ttl).toISOString();
   const claimToken = opts.claimToken ?? "c_test";
@@ -229,6 +241,7 @@ describe("dispatchTaskTool — claim resolution", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -276,6 +289,7 @@ describe("dispatchTaskTool — claim resolution", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -295,6 +309,7 @@ describe("dispatchTaskTool — subcommand resolution", () => {
       subcommand: "no-such-subcmd",
       args: {},
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -336,6 +351,7 @@ describe("dispatchTaskTool — args validation", () => {
       subcommand: "probe",
       args: { foo: { bar: 123 } },
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -367,6 +383,7 @@ describe("dispatchTaskTool — proxy success path", () => {
       subcommand: "probe",
       args: { board_url: "https://example.com" },
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(true);
@@ -390,6 +407,7 @@ describe("dispatchTaskTool — proxy success path", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOKEN_VALUE",
+      nowFn: seededNowFn,
     });
 
     expect(stub!.received[0]?.headers.authorization).toBe("Bearer TOKEN_VALUE");
@@ -410,6 +428,7 @@ describe("dispatchTaskTool — proxy success path", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     const headers = stub!.received[0]!.headers;
@@ -436,6 +455,7 @@ describe("dispatchTaskTool — proxy success path", () => {
       subcommand: "probe",
       args: { board_url: "https://example.com", token: "abc" },
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     const body = stub!.received[0]!.body;
@@ -461,6 +481,7 @@ describe("dispatchTaskTool — publisher failure modes", () => {
       subcommand: "probe",
       args: {},
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -491,6 +512,7 @@ describe("dispatchTaskTool — publisher failure modes", () => {
       args: {},
       bearer: "TOK",
       timeoutMs: 100,
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -547,6 +569,7 @@ describe("dispatchTaskTool — publisher failure modes", () => {
       args: {},
       bearer: "TOK",
       responseCapBytes: 2 * 1024,
+      nowFn: seededNowFn,
     });
 
     expect(result.ok).toBe(false);
@@ -585,6 +608,7 @@ describe("dispatchTaskTool — audit log", () => {
       subcommand: "probe",
       args: { kind: "small" },
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     const rows = db
@@ -635,6 +659,7 @@ describe("dispatchTaskTool — audit log", () => {
       subcommand: "probe",
       args,
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     const r = db
@@ -669,6 +694,7 @@ describe("dispatchTaskTool — audit log", () => {
       subcommand: "probe",
       args: { x: 1 },
       bearer: "TOK",
+      nowFn: seededNowFn,
     });
 
     const rows = db
@@ -705,6 +731,7 @@ describe("dispatchTaskTool — connection pooling", () => {
         subcommand: "probe",
         args: {},
         bearer: "TOK",
+        nowFn: seededNowFn,
       }),
     );
 

--- a/src/dispatch/task_tool.ts
+++ b/src/dispatch/task_tool.ts
@@ -94,8 +94,20 @@ export interface DispatchTaskToolOptions {
    */
   readonly responseCapBytes?: number;
   /**
-   * Override the now() function for deterministic audit timestamps.
-   * Default `() => new Date().toISOString()`.
+   * Override the now() function for deterministic timestamps. Two roles:
+   *
+   *   1. The string returned is bound into the `expires_at > ?` filter
+   *      of the claim-resolution SQL — so this seam ALSO controls the
+   *      claim-expiry comparison, not just audit-row `ts`. Tests that
+   *      seed a fixed `expires_at` MUST pin `nowFn` to a moment within
+   *      that TTL window or the dispatcher will (correctly) report
+   *      `claim_lost`.
+   *   2. The string is reused as the `agent_actions.ts` value of the
+   *      audit row, so a deterministic clock yields a deterministic
+   *      audit log.
+   *
+   * Default `() => new Date().toISOString()`. Mirrors the `nowFn` seam
+   * on M5's `createWorkRoutes` (`src/api/agent/work.ts`).
    */
   readonly nowFn?: () => string;
   /**


### PR DESCRIPTION
## Summary
Fix the 13 wall-clock-fragile failures in `src/dispatch/task_tool.test.ts` introduced after PR #54 merged. The dispatcher already exposed an `nowFn` seam (string ISO timestamp) that gates both the audit-row timestamp AND the `expires_at > ?` SQL comparison in `lookupClaim`; the tests seeded `expires_at = SEEDED_NOW + 10min` but did not pass `nowFn`, so they used the real wall clock and any run after `SEEDED_NOW + 10min` (which today, 2026-04-29 14:09 UTC, is "always") failed claim resolution.

## Related issue
Closes colophon-group/murmur#57

## Files changed (high-level)
- `src/dispatch/task_tool.test.ts` — add a shared `SEEDED_NOW` constant and `seededNowFn`, then thread `nowFn: seededNowFn` through every dispatch call (16 call sites). The one test that already pinned its own `nowFn` (the `Expired claim` case) is left alone since its custom value is necessary to exercise the expiry path.
- `src/dispatch/task_tool.ts` — JSDoc-only tightening on `DispatchTaskToolOptions.nowFn` to flag the dual role (audit `ts` + claim-expiry SQL filter) and reference M5's pattern in `src/api/agent/work.ts`. No behavior change.

## Verification (from the issue)
- [x] Before: `pnpm test src/dispatch/task_tool.test.ts` showed 13 failing / 7 passing
- [x] After: `pnpm test src/dispatch/task_tool.test.ts` shows 20 passing / 0 failing
- [x] After: full `pnpm test` shows 205 passing / 0 failing (root) + 34 passing / 0 failing (`@murmur/contracts-types`)

## Manual checks run locally
- `pnpm typecheck` clean
- `pnpm lint` clean
- `pnpm test` clean (205 + 34 passing)
- `pnpm grep:all` clean

## Notes for reviewer
- Production callers (the future M6 MCP `task_tool` handler, plus any HTTP shim) get the real wall clock by default — `nowFn ?? defaultNowFn` is unchanged. M5 in `src/api/agent/work.ts` uses the identical pattern so a `task_tool` handler can copy that integration verbatim.
- I deliberately did NOT switch to a `nowMs?: number` (single-shot) parameter even though the issue listed it as an option: `nowFn: () => string` matches M5 exactly, the dispatcher already calls it twice (resolve-claim + audit-insert) so a callable seam is more honest than a fixed scalar, and changing the type would be churn for no observable win.
- `seedClaim`'s internal `now = "2026-04-29T12:00:00.000Z"` is now `now = SEEDED_NOW` so the link between the fixture and the test-side pinned clock is one definition.