### PR TITLE
test(integration): cross-repo wire-level full-flow test

### DIFF
--- a/src/integration/README.md
+++ b/src/integration/README.md
@@ -1,0 +1,72 @@
+# Murmur — Integration tests
+
+This directory holds **cross-module wire-level tests** that exercise the
+full stack composition (publisher API + agent API + dispatcher + webhook
+delivery) against an in-process Murmur server and a stub `node:http`
+"publisher" mock. Per-module unit tests still live alongside their
+modules (`src/api/agent/agent.test.ts`, `src/dispatch/task_tool.test.ts`,
+`src/webhook.test.ts`, etc.) — those keep fast iteration cycles and stay
+focused on a single seam at a time. The tests under this directory have
+a higher boot cost (real DB + real HTTP socket on `127.0.0.1:0`) so they
+sit here, run alongside `pnpm test`, and are gated by the same coverage
+configuration.
+
+## What's tested here
+
+`full-flow.test.ts` boots a fresh in-process Murmur on a `:memory:`
+SQLite and starts a tiny mock-jobseek HTTP server on a random port.
+It registers the §3.1 jobseek pipeline def with endpoints pointed at
+the mock, then drives a scripted "agent" loop that:
+
+1. Calls `pull_task` (M5 / `GET /work/next`).
+2. Optionally invokes `task_tool` (M7 / `dispatchTaskTool`) for the
+   subcommands declared on the claimed subtask.
+3. Submits a schema-valid result via `submit_result`
+   (M5 / `POST /work/{claim}/result`).
+
+The assertions cover:
+
+- **Envelope discipline.** Every Murmur-side response is the M0
+  `{ ok, errors?, data? }` shape — there is no `accepted` key anywhere.
+- **Header casing on the wire.** The mock-jobseek captures
+  `req.rawHeaders`, an array preserving the exact mixed-case casing the
+  client emitted (Node lower-cases `req.headers` by default; we look at
+  the raw form). The expected casing is the M0 constant in
+  `@murmur/contracts-types`.
+- **Bearer + idempotency.** Every proxied subcommand carries
+  `Authorization: Bearer <MURMUR_TOKEN>` and the webhook delivery
+  carries `Idempotency-Key: <run_id>`.
+- **Spawns.** A 3-board variant of `list-boards` instantiates 3
+  `configure-board` children, all claimed in FIFO `created_at` order.
+- **Composition.** After all subtasks complete, `final_output` matches
+  the §3.1 example shape produced by the §3.1 `composes` rules.
+- **Webhook replay idempotency.** A second `deliverWebhook` call
+  carrying the same `Idempotency-Key` is observed by the mock-jobseek
+  but the apply-side-effect (a counter on the mock) increments only
+  once.
+
+## Why a separate `src/integration/` directory
+
+Two reasons. (1) Boot cost — these tests open real sockets and run
+real timers (deterministically via injected `setTimeoutFn`). Per-module
+tests remain socket-free where possible. (2) The seam under test is
+the *cross-repo wire contract*, not any one module. A breakage caused
+by drift between Murmur's emitted headers and the contracts-types
+constants would fail here even if every per-module test stays green.
+
+## Running
+
+```bash
+pnpm test -- src/integration
+```
+
+Or as part of the full suite:
+
+```bash
+pnpm test
+```
+
+These tests must not depend on any external service. The mock-jobseek
+listens on `127.0.0.1:0` (kernel-assigned port) and is torn down in
+`afterEach`/`afterAll`. No env vars beyond what the rest of the suite
+sets.

--- a/src/integration/fixtures/jobseek-pipeline.ts
+++ b/src/integration/fixtures/jobseek-pipeline.ts
@@ -61,7 +61,7 @@ export function buildJobseekPipeline(
   opts: BuildJobseekPipelineOptions,
 ): PipelineDef {
   const { apiBase, webhookUrl } = opts;
-  const pipelineId = opts.pipelineId ?? "jobseek/add-company";
+  const pipelineId = opts.pipelineId ?? "jobseek-add-company";
 
   return {
     id: pipelineId,

--- a/src/integration/fixtures/jobseek-pipeline.ts
+++ b/src/integration/fixtures/jobseek-pipeline.ts
@@ -1,0 +1,202 @@
+/**
+ * §3.1 jobseek pipeline def, parameterised on `apiBase` (mock-jobseek
+ * origin + path prefix) and `webhookUrl` so tests can wire it at the
+ * mock instance running on a random port.
+ *
+ * The shape mirrors DESIGN.md §3.1's worked example, trimmed to the
+ * three subtasks the demo exercises end-to-end:
+ *
+ *   - `pre-verify` — confirms the company exists; returns
+ *     `{ verified, canonical_name, canonical_website }`.
+ *   - `list-boards` — returns `{ boards: [...] }` and spawns one
+ *     `configure-board` per element via `spawns: { for_each: boards,
+ *     template: configure-board, bind_as: board }`.
+ *   - `configure-board` — template; per-board outcome.
+ *
+ * The `final_output.composes` rules use:
+ *   - `pre-verify.canonical_*`            — wildcard prefix.
+ *   - `list-boards.boards × configure-board.*` — cartesian (one entry
+ *     per spawned child).
+ *
+ * **Why constructed in TS, not loaded from YAML.** The publisher API
+ * accepts YAML, but the test fixtures want full type-checking on the
+ * pipeline shape (`PipelineDef` from `@murmur/contracts-types`) so
+ * drift between this fixture and the contract types fails at `tsc`,
+ * not at runtime. We serialise the resulting object back to YAML when
+ * we hand it to `POST /pipelines`.
+ */
+
+import type { PipelineDef } from "@murmur/contracts-types";
+
+/**
+ * Options accepted by {@link buildJobseekPipeline}.
+ *
+ * `apiBase` is the mock-jobseek's root URL up to (but excluding) the
+ * `/api/murmur` path the routes live under. The pipeline def appends
+ * the per-route paths. Example: `http://127.0.0.1:54321`.
+ *
+ * `webhookUrl` is the full URL Murmur will POST `final_output` to.
+ * Example: `http://127.0.0.1:54321/api/murmur/accept`.
+ *
+ * `pipelineId` lets a test register multiple pipelines in the same DB
+ * without colliding on the upsert key.
+ */
+export interface BuildJobseekPipelineOptions {
+  readonly apiBase: string;
+  readonly webhookUrl: string;
+  readonly pipelineId?: string;
+}
+
+/**
+ * Return a complete `PipelineDef` matching DESIGN.md §3.1 with all
+ * subcommand `endpoint` URLs and the `final_output.webhook` pointed at
+ * `apiBase`/`webhookUrl`.
+ *
+ * The returned object is structurally compatible with the
+ * `pipeline-def.schema.json` JSON Schema gating `POST /pipelines`. The
+ * caller is responsible for stringifying it (we serialise via the YAML
+ * lib for the publisher route's wire shape).
+ */
+export function buildJobseekPipeline(
+  opts: BuildJobseekPipelineOptions,
+): PipelineDef {
+  const { apiBase, webhookUrl } = opts;
+  const pipelineId = opts.pipelineId ?? "jobseek/add-company";
+
+  return {
+    id: pipelineId,
+    initial_input: {
+      type: "object",
+      required: ["company_name", "website"],
+      properties: {
+        company_name: { type: "string", minLength: 1 },
+        website: { type: "string", format: "uri" },
+      },
+      additionalProperties: false,
+    },
+    subtasks: [
+      {
+        id: "pre-verify",
+        instructions:
+          "Confirm this is a real, non-duplicate company with a careers page.",
+        output_schema: {
+          type: "object",
+          required: ["verified", "canonical_name", "canonical_website"],
+          properties: {
+            verified: { type: "boolean" },
+            canonical_name: { type: "string", minLength: 1 },
+            canonical_website: { type: "string", format: "uri" },
+          },
+          additionalProperties: false,
+        },
+        subcommands: [
+          {
+            name: "verify company",
+            endpoint: `POST ${apiBase}/api/murmur/companies/verify`,
+            input_schema: {
+              type: "object",
+              required: ["website"],
+              properties: { website: { type: "string", format: "uri" } },
+              additionalProperties: false,
+            },
+          },
+        ],
+      },
+      {
+        id: "list-boards",
+        instructions:
+          "Discover all distinct boards. Cross-board reconciliation runs in the accept handler — do not dedupe yourself.",
+        requires: ["pre-verify"],
+        output_schema: {
+          type: "object",
+          required: ["boards"],
+          properties: {
+            boards: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["alias", "url", "provider"],
+                properties: {
+                  alias: { type: "string", minLength: 1 },
+                  url: { type: "string", format: "uri" },
+                  provider: { type: "string", minLength: 1 },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
+          additionalProperties: false,
+        },
+        spawns: {
+          for_each: "boards",
+          template: "configure-board",
+          bind_as: "board",
+        },
+        subcommands: [
+          {
+            name: "analyze hreflang",
+            endpoint: `POST ${apiBase}/api/murmur/probes/monitor`,
+          },
+        ],
+      },
+      {
+        id: "configure-board",
+        instructions:
+          "Configure monitor and (when needed) scraper for this board.",
+        output_schema: {
+          type: "object",
+          required: ["outcome"],
+          properties: {
+            outcome: {
+              type: "string",
+              enum: ["configured", "phantom", "parent-portal", "unsupported"],
+            },
+            monitor_type: { type: "string" },
+            monitor_config: { type: "object" },
+            scraper_type: { type: "string" },
+            scraper_config: { type: "object" },
+            verdict: { type: "string", enum: ["good", "acceptable", "bad"] },
+          },
+          additionalProperties: false,
+        },
+        subcommands: [
+          {
+            name: "probe monitor",
+            endpoint: `POST ${apiBase}/api/murmur/probes/monitor`,
+          },
+          {
+            name: "select monitor",
+            endpoint: `POST ${apiBase}/api/murmur/select/monitor`,
+          },
+          {
+            name: "run monitor",
+            endpoint: `POST ${apiBase}/api/murmur/run/monitor`,
+          },
+          {
+            name: "probe scraper",
+            endpoint: `POST ${apiBase}/api/murmur/probes/scraper`,
+          },
+          {
+            name: "select scraper",
+            endpoint: `POST ${apiBase}/api/murmur/select/scraper`,
+          },
+          {
+            name: "run scraper",
+            endpoint: `POST ${apiBase}/api/murmur/run/scraper`,
+          },
+          {
+            name: "feedback",
+            endpoint: `POST ${apiBase}/api/murmur/feedback`,
+          },
+        ],
+      },
+    ],
+    final_output: {
+      composes: [
+        "pre-verify.canonical_*",
+        "boards: list-boards.boards × configure-board.*",
+      ],
+      webhook: webhookUrl,
+    },
+  };
+}

--- a/src/integration/full-flow.test.ts
+++ b/src/integration/full-flow.test.ts
@@ -227,6 +227,9 @@ async function startRun(harness: IntegrationHarness): Promise<string> {
       `startRun returned ok=false: ${JSON.stringify(env.errors)}`,
     );
   }
+  if (env.data === undefined) {
+    throw new Error("startRun: ok envelope without data");
+  }
   const runId = env.data.run_id;
 
   // Insert `pending` rows for every static subtask whose `requires` is

--- a/src/integration/full-flow.test.ts
+++ b/src/integration/full-flow.test.ts
@@ -1,0 +1,787 @@
+/**
+ * Cross-repo integration test (issue #35 / I1) — end-to-end wire-level
+ * verification that Murmur's `task_tool` proxy and `webhook` delivery
+ * compose with a stub jobseek over real HTTP, with envelope shape and
+ * header casing matching M0 contracts.
+ *
+ * Test bullets are taken verbatim from issue #35's "Verification"
+ * section; every named bullet has at least one corresponding `it()`
+ * below.
+ *
+ * The mock-jobseek runs on `127.0.0.1:0` (kernel-assigned port) and
+ * captures `req.rawHeaders` so we can assert on the wire-cased header
+ * names. The Murmur side is in-process via Hono's `app.request(...)`
+ * — no TCP socket, but the dispatcher's outbound `task_tool` calls
+ * and the webhook delivery DO go over the wire (to the mock).
+ */
+
+import Database from "better-sqlite3";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { Hono } from "hono";
+
+import {
+  MurmurHeaders,
+  type EnvelopeResponse,
+  type PipelineDef,
+  type Err,
+} from "@murmur/contracts-types";
+
+import { createAgentApp } from "../api/agent/index.js";
+import { createPublisherApp } from "../api/publisher/index.js";
+import { bearerAuth } from "../auth/index.js";
+import { runMigrations } from "../db/migrate.js";
+import { closeAllPools } from "../dispatch/task_tool.js";
+import { createMcpRoute } from "../mcp/server.js";
+import {
+  awaitPendingWebhookDeliveries,
+  deliverWebhook,
+  resetPendingWebhookDeliveriesForTest,
+  type WebhookFetch,
+  type WebhookSetTimeout,
+} from "../webhook.js";
+
+import {
+  buildJobseekPipeline,
+  type BuildJobseekPipelineOptions,
+} from "./fixtures/jobseek-pipeline.js";
+import {
+  findRawHeader,
+  startMockJobseek,
+  type MockJobseek,
+  type RecordedRequest,
+} from "./mock-jobseek.js";
+import {
+  runScriptedAgent,
+  type BoardSpec,
+  type TaskToolResponse,
+} from "./scripted-agent.js";
+
+/* -------------------------------------------------------------------- */
+/* Fixtures                                                              */
+/* -------------------------------------------------------------------- */
+
+const TEST_TOKEN = "integration-test-murmur-token";
+const TEST_TOKEN_BUF = Buffer.from(TEST_TOKEN, "utf8");
+
+interface IntegrationHarness {
+  readonly db: Database.Database;
+  readonly app: Hono;
+  readonly mock: MockJobseek;
+  readonly pipelineId: string;
+  readonly pipelineDef: PipelineDef;
+  /**
+   * Promises for in-flight first-attempt webhook deliveries. Tests
+   * `await Promise.allSettled(harness.webhookFirstAttempts)` between the
+   * scripted agent finishing and reading `runs.webhook_status`. The
+   * production wiring in `src/server.ts` is fire-and-forget — we
+   * mirror it here but ALSO retain the promises so the test can
+   * synchronise against them deterministically (no `setTimeout(0)`
+   * polling, no flaky waits).
+   */
+  readonly webhookFirstAttempts: Promise<void>[];
+}
+
+/**
+ * Build a Hono app structurally identical to `createServer` but with
+ * a webhook-delivery hook the test can synchronise against.
+ *
+ * The shape mirrors `src/server.ts` so any drift in production wiring
+ * surfaces here as a test failure (the harness composes the same
+ * `bearerAuth`, `createPublisherApp`, `createAgentApp`,
+ * `createMcpRoute` primitives in the same order).
+ */
+function buildHarnessApp(
+  db: Database.Database,
+  token: Buffer,
+  webhookFirstAttempts: Promise<void>[],
+): Hono {
+  const app = new Hono();
+  app.use("*", bearerAuth(token));
+  app.get("/health", (c) => c.json({ ok: true }));
+
+  const publisher = createPublisherApp({ db });
+  app.route("/", publisher);
+
+  const tokenStr = token.toString("utf8");
+  const deliverWebhookFn = (runId: string): void => {
+    const p = deliverWebhook(db, runId, { bearer: tokenStr }).catch(() => {
+      // Surface nothing — `deliverWebhook` already logs internally and
+      // the test asserts on observable state (DB rows + mock log),
+      // not on rejection of this promise. Swallowing matches the
+      // production wiring in `src/server.ts`.
+    });
+    webhookFirstAttempts.push(p);
+  };
+
+  const agent = createAgentApp({ db, deliverWebhookFn });
+  app.route("/work", agent);
+  app.route("/mcp", createMcpRoute({ agentApp: agent }));
+
+  app.notFound((c) => {
+    const body: Err = { ok: false, errors: ["not_found"] };
+    return c.json(body, 404);
+  });
+
+  return app;
+}
+
+/**
+ * Boot the in-process Murmur, start a fresh mock-jobseek, and register
+ * the §3.1 pipeline pointed at the mock. Returns a handle each test
+ * uses to drive the loop and assert on captured wire data.
+ *
+ * Each test gets its own DB + mock — the integration test's value is
+ * in the cross-module composition, but cross-test contamination would
+ * obscure failures.
+ */
+async function startHarness(
+  pipelineId = "jobseek-add-company",
+): Promise<IntegrationHarness> {
+  const mock = await startMockJobseek();
+
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  runMigrations(db);
+
+  const webhookFirstAttempts: Promise<void>[] = [];
+  const app = buildHarnessApp(db, TEST_TOKEN_BUF, webhookFirstAttempts);
+
+  const opts: BuildJobseekPipelineOptions = {
+    apiBase: mock.origin,
+    webhookUrl: `${mock.origin}/api/murmur/accept`,
+    pipelineId,
+  };
+  const pipelineDef = buildJobseekPipeline(opts);
+
+  // Seed the pipeline def directly into `pipelines` (the same path the
+  // dispatcher's unit tests take in `src/dispatch/task_tool.test.ts`).
+  // We deliberately bypass `POST /pipelines` here because:
+  //
+  //   - The M0 schema regex pins endpoints to `^POST https://` and the
+  //     webhook to `^https://` (`docs/contracts/pipeline-def.schema.json`).
+  //   - The mock-jobseek runs on plain `http://127.0.0.1:<port>` because
+  //     opening a self-signed TLS cert in a test would balloon scope and
+  //     a TLS handshake adds nothing to the wire-contract assertion the
+  //     test cares about.
+  //
+  // The dispatcher reads `pipelines.def_json` verbatim, so seeding the
+  // row directly preserves every M0 contract this test asserts on
+  // (header casing, envelope shape, idempotency-key) — only the regex
+  // gate at registration is sidestepped.
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO pipelines (id, version, def_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(pipelineId, 1, JSON.stringify(pipelineDef), now, now);
+
+  return { db, app, mock, pipelineId, pipelineDef, webhookFirstAttempts };
+}
+
+/**
+ * Block until every fire-and-forget first-attempt webhook delivery
+ * AND every scheduled retry has settled. Combines the harness-tracked
+ * first-attempt promises with the webhook module's
+ * `awaitPendingWebhookDeliveries` (which only covers retries).
+ */
+async function drainWebhooks(harness: IntegrationHarness): Promise<void> {
+  // First attempts that the harness's `deliverWebhookFn` started.
+  await Promise.allSettled(harness.webhookFirstAttempts);
+  // Then any retry that may have been scheduled.
+  await awaitPendingWebhookDeliveries();
+}
+
+async function startRun(harness: IntegrationHarness): Promise<string> {
+  const response = await harness.app.request(
+    `/pipelines/${encodeURIComponent(harness.pipelineId)}/runs`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        initial_input: {
+          company_name: "Example, Inc.",
+          website: "https://example.com",
+        },
+      }),
+    },
+  );
+  if (response.status !== 200) {
+    const body = await response.text();
+    throw new Error(`startRun: ${response.status}: ${body}`);
+  }
+  const env = (await response.json()) as EnvelopeResponse<{ run_id: string }>;
+  if (!env.ok) {
+    throw new Error(
+      `startRun returned ok=false: ${JSON.stringify(env.errors)}`,
+    );
+  }
+  const runId = env.data.run_id;
+
+  // Insert `pending` rows for every static subtask whose `requires` is
+  // non-empty. The publisher route only inserts the run-start ready set
+  // (subtasks with no `requires` and not a spawn template); the
+  // `markNextReady` lifecycle helper expects `pending` rows to exist
+  // for it to flip to `ready` after their prerequisites complete.
+  // The same pattern is used by `src/api/agent/agent.test.ts#seedRun`.
+  const templates = new Set<string>();
+  for (const s of harness.pipelineDef.subtasks) {
+    if (s.spawns !== undefined) templates.add(s.spawns.template);
+  }
+  const insertPending = harness.db.prepare(
+    `INSERT OR IGNORE INTO subtask_instances
+       (id, run_id, subtask_id, status, input_json, created_at, updated_at)
+     VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
+  );
+  let i = 0;
+  const baseTime = Date.now();
+  for (const sub of harness.pipelineDef.subtasks) {
+    const reqs = sub.requires ?? [];
+    if (reqs.length === 0) continue;
+    if (templates.has(sub.id)) continue;
+    // Stagger created_at by ms so FIFO order is deterministic.
+    const ts = new Date(baseTime + i).toISOString();
+    insertPending.run(
+      `i_pending_${runId}_${sub.id}`,
+      runId,
+      sub.id,
+      "{}",
+      ts,
+      ts,
+    );
+    i += 1;
+  }
+  return runId;
+}
+
+/* -------------------------------------------------------------------- */
+/* Cleanup                                                               */
+/* -------------------------------------------------------------------- */
+
+let harness: IntegrationHarness | undefined;
+
+beforeEach(() => {
+  // Reset the webhook module's in-flight registry so a previous test's
+  // detached retry can't leak into this one.
+  resetPendingWebhookDeliveriesForTest();
+});
+
+afterEach(async () => {
+  // Drain any in-flight first-attempts AND retries before closing
+  // sockets so they don't explode against a closed mock.
+  if (harness !== undefined) {
+    await drainWebhooks(harness);
+    harness.db.close();
+    await harness.mock.close();
+    harness = undefined;
+  } else {
+    await awaitPendingWebhookDeliveries();
+  }
+  // Close any pools the dispatcher cached so the next test gets a
+  // fresh client (origin keepalive sockets to a closed mock would
+  // surface as ECONNREFUSED on the next call otherwise).
+  await closeAllPools();
+});
+
+afterAll(async () => {
+  await closeAllPools();
+});
+
+/* -------------------------------------------------------------------- */
+/* Helpers                                                               */
+/* -------------------------------------------------------------------- */
+
+const ENVELOPE_NEVER_HAS_ACCEPTED = (env: EnvelopeResponse<unknown>): void => {
+  // Strict: serialise and ensure no `accepted` JSON key appears anywhere
+  // in the body, no matter how nested. Issue #35 specifies this exact
+  // assertion. (grep-no-accepted-key:allow — load-bearing assertion.)
+  expect(JSON.stringify(env)).not.toMatch(/"accepted"/);
+};
+
+const ASSERT_M0_ENVELOPE = (
+  env: EnvelopeResponse<unknown>,
+  context: string,
+): void => {
+  // The envelope MUST be either { ok: true, data: ... } or
+  // { ok: false, errors: [...] }. No other shape.
+  if (env === null || typeof env !== "object") {
+    throw new Error(`${context}: envelope is not an object`);
+  }
+  if (typeof env.ok !== "boolean") {
+    throw new Error(`${context}: envelope.ok is not a boolean`);
+  }
+  if (env.ok) {
+    expect(env, `${context}: ok envelope must have data`).toHaveProperty("data");
+  } else {
+    expect(env, `${context}: err envelope must have errors`).toHaveProperty(
+      "errors",
+    );
+    expect(
+      Array.isArray(env.errors),
+      `${context}: errors must be an array`,
+    ).toBe(true);
+  }
+  ENVELOPE_NEVER_HAS_ACCEPTED(env);
+};
+
+/**
+ * Filter a {@link RecordedRequest} log down to the requests against a
+ * specific URL path. Used to gate header-casing assertions to the
+ * routes the test actually exercised.
+ */
+function requestsTo(
+  log: ReadonlyArray<RecordedRequest>,
+  pathPrefix: string,
+): ReadonlyArray<RecordedRequest> {
+  return log.filter((r) => r.url.startsWith(pathPrefix));
+}
+
+/* -------------------------------------------------------------------- */
+/* Tests                                                                 */
+/* -------------------------------------------------------------------- */
+
+describe("integration: cross-repo full flow", () => {
+  it("Happy path single-board run completes", async () => {
+    harness = await startHarness();
+    const runId = await startRun(harness);
+
+    const taskToolCalls: TaskToolResponse[] = [];
+    const murmurCalls: EnvelopeResponse<unknown>[] = [];
+
+    const board: BoardSpec = {
+      alias: "careers-en",
+      url: "https://example.com/careers",
+      provider: "greenhouse",
+    };
+
+    const result = await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [board],
+      taskToolCalls,
+      murmurCalls,
+    });
+
+    expect(result.runId).toBe(runId);
+    // Subtask order: pre-verify, list-boards, configure-board × 1.
+    expect(result.claimedSubtaskOrder.map((c) => c.subtaskId)).toEqual([
+      "pre-verify",
+      "list-boards",
+      "configure-board",
+    ]);
+
+    // Drain any scheduled webhook retry (there shouldn't be one — the
+    // mock returns 200 — but wait anyway so the assertion is robust).
+    await drainWebhooks(harness);
+
+    // Run row reflects completion.
+    const runRow = harness.db
+      .prepare(`SELECT status, webhook_status FROM runs WHERE id = ?`)
+      .get(runId) as { status: string; webhook_status: string | null };
+    expect(
+      runRow.status,
+      "run status must flip to 'completed' after final submit",
+    ).toBe("completed");
+    expect(
+      runRow.webhook_status,
+      "webhook_status must be 'delivered' on a 2xx accept response",
+    ).toBe("delivered");
+  });
+
+  it("3-board spawn run completes; all 3 children claimed in created_at order", async () => {
+    harness = await startHarness();
+    await startRun(harness);
+
+    const boards: BoardSpec[] = [
+      { alias: "careers-en", url: "https://example.com/en", provider: "greenhouse" },
+      { alias: "careers-de", url: "https://example.com/de", provider: "greenhouse" },
+      { alias: "careers-fr", url: "https://example.com/fr", provider: "lever" },
+    ];
+
+    const result = await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards,
+    });
+
+    // pre-verify, list-boards, then 3 × configure-board in spawn order.
+    expect(result.claimedSubtaskOrder.map((c) => c.subtaskId)).toEqual([
+      "pre-verify",
+      "list-boards",
+      "configure-board",
+      "configure-board",
+      "configure-board",
+    ]);
+
+    // Each spawned child's `input.board` matches the corresponding
+    // boards[] element (FIFO via `created_at` per M5).
+    const configureClaims = result.claimedSubtaskOrder.filter(
+      (c) => c.subtaskId === "configure-board",
+    );
+    expect(configureClaims).toHaveLength(3);
+    for (let i = 0; i < boards.length; i += 1) {
+      const inp = configureClaims[i]?.input as { board?: BoardSpec };
+      expect(
+        inp?.board?.alias,
+        `configure-board #${i} must bind the matching board element under 'board'`,
+      ).toBe(boards[i]?.alias);
+    }
+
+    // DB confirms all 3 spawn rows ended `done`.
+    const childRows = harness.db
+      .prepare(
+        `SELECT status FROM subtask_instances
+          WHERE subtask_id = 'configure-board'
+       ORDER BY created_at ASC`,
+      )
+      .all() as ReadonlyArray<{ status: string }>;
+    expect(childRows).toHaveLength(3);
+    for (const r of childRows) {
+      expect(r.status).toBe("done");
+    }
+  });
+
+  it("task_tool envelope stays M0-shaped across all routes", async () => {
+    harness = await startHarness();
+    await startRun(harness);
+
+    const taskToolCalls: TaskToolResponse[] = [];
+    const murmurCalls: EnvelopeResponse<unknown>[] = [];
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+        { alias: "b", url: "https://example.com/b", provider: "lever" },
+      ],
+      taskToolCalls,
+      murmurCalls,
+    });
+
+    // Every dispatcher response is M0-shaped.
+    expect(
+      taskToolCalls.length,
+      "expected at least one task_tool call across pre-verify + list-boards + configure-board",
+    ).toBeGreaterThan(0);
+    for (let i = 0; i < taskToolCalls.length; i += 1) {
+      const call = taskToolCalls[i];
+      if (call === undefined) continue;
+      ASSERT_M0_ENVELOPE(call, `taskToolCalls[${i}]`);
+    }
+    for (let i = 0; i < murmurCalls.length; i += 1) {
+      const call = murmurCalls[i];
+      if (call === undefined) continue;
+      ASSERT_M0_ENVELOPE(call, `murmurCalls[${i}]`);
+    }
+  });
+
+  it("Header casing matches M0 constants on every proxied task_tool call", async () => {
+    harness = await startHarness();
+    await startRun(harness);
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+      ],
+    });
+
+    const proxied = harness.mock.received.filter(
+      (r) => r.url.startsWith("/api/murmur/") && r.url !== "/api/murmur/accept",
+    );
+    expect(
+      proxied.length,
+      "scripted agent should issue at least one task_tool proxied call",
+    ).toBeGreaterThan(0);
+
+    for (let i = 0; i < proxied.length; i += 1) {
+      const req = proxied[i];
+      if (req === undefined) continue;
+      const ctx = `proxied[${i}] ${req.method} ${req.url}`;
+
+      // Authorization header — exact M0 casing.
+      const authz = findRawHeader(req.rawHeaders, MurmurHeaders.AUTHORIZATION);
+      expect(authz, `${ctx}: missing Authorization header`).not.toBeNull();
+      expect(
+        authz?.nameOnWire,
+        `${ctx}: Authorization header casing must match M0 constant`,
+      ).toBe(MurmurHeaders.AUTHORIZATION);
+
+      // X-Murmur-Subcommand — exact M0 casing.
+      const sub = findRawHeader(
+        req.rawHeaders,
+        MurmurHeaders.X_MURMUR_SUBCOMMAND,
+      );
+      expect(sub, `${ctx}: missing X-Murmur-Subcommand header`).not.toBeNull();
+      expect(
+        sub?.nameOnWire,
+        `${ctx}: X-Murmur-Subcommand header casing must match M0 constant`,
+      ).toBe(MurmurHeaders.X_MURMUR_SUBCOMMAND);
+      expect(
+        sub?.value,
+        `${ctx}: X-Murmur-Subcommand value must be a non-empty string`,
+      ).toBeTruthy();
+
+      // X-Murmur-Claim-Token — exact M0 casing.
+      const claim = findRawHeader(
+        req.rawHeaders,
+        MurmurHeaders.X_MURMUR_CLAIM_TOKEN,
+      );
+      expect(
+        claim,
+        `${ctx}: missing X-Murmur-Claim-Token header`,
+      ).not.toBeNull();
+      expect(
+        claim?.nameOnWire,
+        `${ctx}: X-Murmur-Claim-Token header casing must match M0 constant`,
+      ).toBe(MurmurHeaders.X_MURMUR_CLAIM_TOKEN);
+      expect(
+        claim?.value,
+        `${ctx}: X-Murmur-Claim-Token must be a non-empty string`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("Mock-jobseek receives bearer with MURMUR_TOKEN on proxied subcommand calls", async () => {
+    harness = await startHarness();
+    await startRun(harness);
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+      ],
+    });
+
+    const proxied = harness.mock.received.filter(
+      (r) => r.url.startsWith("/api/murmur/") && r.url !== "/api/murmur/accept",
+    );
+    expect(proxied.length).toBeGreaterThan(0);
+
+    for (let i = 0; i < proxied.length; i += 1) {
+      const req = proxied[i];
+      if (req === undefined) continue;
+      const ctx = `proxied[${i}] ${req.method} ${req.url}`;
+      const authz = findRawHeader(req.rawHeaders, MurmurHeaders.AUTHORIZATION);
+      expect(authz?.value, `${ctx}: bearer must be present`).toBe(
+        `Bearer ${TEST_TOKEN}`,
+      );
+    }
+  });
+
+  it("Webhook delivery: bearer + Idempotency-Key visible in mock-jobseek's accept handler", async () => {
+    harness = await startHarness();
+    const runId = await startRun(harness);
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+      ],
+    });
+    await drainWebhooks(harness);
+
+    const accepts = requestsTo(harness.mock.received, "/api/murmur/accept");
+    expect(
+      accepts.length,
+      "expected exactly one webhook delivery on first happy-path completion",
+    ).toBe(1);
+
+    const accept = accepts[0];
+    if (accept === undefined) throw new Error("unreachable");
+
+    // Bearer.
+    const authz = findRawHeader(
+      accept.rawHeaders,
+      MurmurHeaders.AUTHORIZATION,
+    );
+    expect(authz?.value, "webhook bearer must equal MURMUR_TOKEN").toBe(
+      `Bearer ${TEST_TOKEN}`,
+    );
+
+    // Idempotency-Key.
+    const idem = findRawHeader(
+      accept.rawHeaders,
+      MurmurHeaders.IDEMPOTENCY_KEY,
+    );
+    expect(
+      idem,
+      "webhook MUST include Idempotency-Key header (M0 contract)",
+    ).not.toBeNull();
+    expect(
+      idem?.value,
+      "Idempotency-Key MUST equal run_id (M0 contract)",
+    ).toBe(runId);
+
+    // Body shape — Murmur's M10 webhook ships the composed `final_output`
+    // directly as the JSON body (no `{ run_id, pipeline_id, ...,
+    // final_output }` wrapper). The Idempotency-Key header carries the
+    // run_id; the publisher-side dedupes on that. The body's content is
+    // the §3.1 composed shape.
+    const finalOutput = JSON.parse(accept.body) as Record<string, unknown>;
+    // §3.1 composes:
+    //   - pre-verify.canonical_*  → canonical_name + canonical_website
+    //   - boards: list-boards.boards × configure-board.*
+    expect(finalOutput).toMatchObject({
+      canonical_name: "Example, Inc.",
+      canonical_website: "https://example.com",
+    });
+    expect(
+      Array.isArray(finalOutput.boards),
+      "final_output.boards must be an array (§3.1 cartesian compose rule)",
+    ).toBe(true);
+    const boardsArr = finalOutput.boards as ReadonlyArray<
+      Record<string, unknown>
+    >;
+    expect(boardsArr).toHaveLength(1);
+    expect(boardsArr[0]).toMatchObject({
+      alias: "a",
+      outcome: "configured",
+      monitor_type: "rss",
+    });
+  });
+
+  it("Webhook replay (one retry): mock-jobseek receives 2 calls, applies side-effect once", async () => {
+    harness = await startHarness();
+    const runId = await startRun(harness);
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+      ],
+    });
+    await drainWebhooks(harness);
+
+    // Sanity: first delivery happened.
+    expect(
+      harness.mock.acceptApplyCount(),
+      "first webhook delivery should have applied once",
+    ).toBe(1);
+    expect(harness.mock.seenIdempotencyKeys()).toEqual([runId]);
+
+    const beforeReplay = requestsTo(harness.mock.received, "/api/murmur/accept")
+      .length;
+
+    // Simulate a Murmur retry: reset webhook_status to 'pending' so the
+    // idempotency guard inside `deliverWebhook` does not short-circuit,
+    // then re-invoke. We use a deterministic immediate-fire scheduler
+    // so the (potential) one retry runs synchronously, but our mock
+    // returns 200 first attempt so no retry will fire here either way.
+    harness.db
+      .prepare(`UPDATE runs SET webhook_status = 'pending' WHERE id = ?`)
+      .run(runId);
+
+    const fakeSetTimeout: WebhookSetTimeout = (cb, _ms) => {
+      // Run sync — safe because we never throw inside cb in this test.
+      cb();
+      return 0;
+    };
+    // Wrap the default fetch via a thin pass-through so we don't have
+    // to re-implement the undici call. The webhook module's default
+    // transport is fine; we only need to control the scheduler here.
+    const passThroughFetch: WebhookFetch = async (url, init) => {
+      const { request } = await import("undici");
+      const res = await request(url, {
+        method: "POST",
+        headers: init.headers,
+        body: init.body,
+      });
+      // Drain.
+      try {
+        for await (const _ of res.body) void _;
+      } catch {
+        // ignore
+      }
+      return { status: res.statusCode };
+    };
+
+    await deliverWebhook(harness.db, runId, {
+      bearer: TEST_TOKEN,
+      setTimeoutFn: fakeSetTimeout,
+      fetchImpl: passThroughFetch,
+    });
+    await drainWebhooks(harness);
+
+    const afterReplay = requestsTo(harness.mock.received, "/api/murmur/accept")
+      .length;
+    expect(
+      afterReplay - beforeReplay,
+      "second deliverWebhook call must be visible to mock-jobseek",
+    ).toBe(1);
+
+    // Apply side-effect: still ONE distinct Idempotency-Key applied
+    // (the publisher is idempotent on the writer side).
+    expect(
+      harness.mock.acceptApplyCount(),
+      "duplicate Idempotency-Key must NOT increment the apply counter",
+    ).toBe(1);
+    expect(harness.mock.seenIdempotencyKeys()).toEqual([runId]);
+
+    // Second delivery's Idempotency-Key matches the first.
+    const accepts = requestsTo(harness.mock.received, "/api/murmur/accept");
+    expect(accepts).toHaveLength(2);
+    const idem0 = findRawHeader(
+      accepts[0]!.rawHeaders,
+      MurmurHeaders.IDEMPOTENCY_KEY,
+    );
+    const idem1 = findRawHeader(
+      accepts[1]!.rawHeaders,
+      MurmurHeaders.IDEMPOTENCY_KEY,
+    );
+    expect(idem0?.value).toBe(runId);
+    expect(idem1?.value).toBe(runId);
+  });
+
+  it("No envelope ever carries an `accepted` key (strict M0 enforcement)", async () => {
+    harness = await startHarness();
+    await startRun(harness);
+
+    const taskToolCalls: TaskToolResponse[] = [];
+    const murmurCalls: EnvelopeResponse<unknown>[] = [];
+
+    await runScriptedAgent({
+      app: harness.app,
+      db: harness.db,
+      bearer: TEST_TOKEN,
+      boards: [
+        { alias: "a", url: "https://example.com/a", provider: "greenhouse" },
+      ],
+      taskToolCalls,
+      murmurCalls,
+    });
+    await drainWebhooks(harness);
+
+    // Every captured envelope.
+    for (const env of [...taskToolCalls, ...murmurCalls]) {
+      expect(JSON.stringify(env)).not.toMatch(/"accepted"/);
+    }
+    // Every body the mock received (Murmur-generated outbound traffic).
+    for (const req of harness.mock.received) {
+      expect(req.body).not.toMatch(/"accepted"/);
+    }
+  });
+});

--- a/src/integration/mock-jobseek.ts
+++ b/src/integration/mock-jobseek.ts
@@ -35,12 +35,7 @@
  *     is jobseek-side and out of scope here).
  */
 
-import {
-  createServer,
-  type IncomingMessage,
-  type Server,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 
 /**

--- a/src/integration/mock-jobseek.ts
+++ b/src/integration/mock-jobseek.ts
@@ -1,0 +1,216 @@
+/**
+ * Mock-jobseek HTTP server — a stand-in publisher used by the
+ * integration tests. Listens on `127.0.0.1:0` (kernel-assigned port)
+ * and records every incoming request's method, URL, raw headers, and
+ * body to an in-memory log so the tests can assert wire-level details.
+ *
+ * The server exposes the seven `task_tool`-proxied routes plus the
+ * `/api/murmur/accept` webhook receiver. Each route returns a stub
+ * envelope `{ ok: true, data: ... }` shaped roughly like what the real
+ * jobseek's J5 surface returns. The exact body shape is not
+ * load-bearing for the integration test (the test asserts the *flow*,
+ * not the publisher's internal logic) but keeping it close to reality
+ * makes the failure mode easy to read.
+ *
+ * Key observations the test relies on:
+ *
+ *   - **`req.rawHeaders`**: Node's `req.headers` lower-cases names by
+ *     default, so a header asserted as `X-Murmur-Subcommand` would pass
+ *     even if the client emitted `x-murmur-subcommand`. The raw form
+ *     preserves casing as it appeared on the wire. The mock records
+ *     the array verbatim (same `[name, value, name, value, ...]` shape)
+ *     and the test scans it for the M0-constant strings.
+ *
+ *   - **Webhook idempotency**: the `/api/murmur/accept` handler tracks
+ *     applied `Idempotency-Key` values in an in-memory `Set`. The
+ *     "apply side-effect" is incrementing a counter; on a duplicate
+ *     key the counter does NOT increment. Both cases still 200 — the
+ *     publisher is idempotent on the writer side, not the receiver
+ *     side, exactly as DESIGN.md §3.6 specifies.
+ *
+ *   - **Bearer captured but not validated**: the mock does not enforce
+ *     the bearer; it only records what arrived. The tests assert on
+ *     the captured value. This keeps the test focused on the cross-repo
+ *     contract Murmur emits, not on the publisher's auth policy (which
+ *     is jobseek-side and out of scope here).
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Minimal record of one HTTP request the mock observed. `rawHeaders`
+ * is the verbatim array from `req.rawHeaders`: an even-length array of
+ * `[name, value, name, value, ...]` with case preserved.
+ */
+export interface RecordedRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly rawHeaders: ReadonlyArray<string>;
+  readonly body: string;
+}
+
+/**
+ * Public surface of the running mock. `origin` is the `http://127.0.0.1:<port>`
+ * URL the test should use as `apiBase` when building pipeline defs.
+ *
+ * `acceptApplyCount` is the number of distinct `Idempotency-Key`s the
+ * webhook handler has "applied" — the load-bearing assertion for the
+ * idempotency replay test.
+ */
+export interface MockJobseek {
+  readonly origin: string;
+  readonly received: ReadonlyArray<RecordedRequest>;
+  readonly acceptApplyCount: () => number;
+  readonly seenIdempotencyKeys: () => ReadonlyArray<string>;
+  readonly close: () => Promise<void>;
+}
+
+/**
+ * Stub envelope returned by every non-accept route. Shape matches
+ * Murmur's M0 envelope on the response side too — the dispatcher
+ * surfaces this verbatim under `data` of the `task_tool` response.
+ */
+function defaultStubBody(path: string): unknown {
+  // Branch on path so every route's stub looks superficially route-shaped
+  // (e.g., a probe returns a candidate list; a select returns an ack).
+  if (path.endsWith("/probes/monitor") || path.endsWith("/probes/scraper")) {
+    return {
+      ok: true,
+      data: {
+        candidates: [
+          { type: "rss", confidence: 0.9 },
+          { type: "html", confidence: 0.6 },
+        ],
+      },
+    };
+  }
+  if (path.endsWith("/run/monitor") || path.endsWith("/run/scraper")) {
+    return {
+      ok: true,
+      data: { count: 12, samples: ["job-1", "job-2"] },
+    };
+  }
+  if (path.endsWith("/select/monitor") || path.endsWith("/select/scraper")) {
+    return { ok: true, data: { stored_as: "cfg-1" } };
+  }
+  if (path.endsWith("/feedback")) {
+    return { ok: true, data: { recorded: true } };
+  }
+  if (path.endsWith("/companies/verify")) {
+    return {
+      ok: true,
+      data: { exists: true, careers_page: "https://example.com/careers" },
+    };
+  }
+  // Catch-all: still M0-shaped.
+  return { ok: true, data: {} };
+}
+
+/**
+ * Start a mock-jobseek HTTP server. The returned promise resolves once
+ * the kernel has assigned a port and the server is `listen`ing.
+ *
+ * The server is deliberately stateful: every request appends a new
+ * {@link RecordedRequest} to the internal log. Tests assert on the log
+ * after the scripted agent finishes its loop.
+ */
+export async function startMockJobseek(): Promise<MockJobseek> {
+  const received: RecordedRequest[] = [];
+  const appliedKeys: Set<string> = new Set();
+
+  const server: Server = createServer((req, res) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      // Capture verbatim — DO NOT downcase headers here; the whole
+      // point of the integration test is to assert the wire-cased
+      // strings the client emitted.
+      received.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        rawHeaders: [...req.rawHeaders],
+        body,
+      });
+
+      const url = req.url ?? "";
+
+      // Webhook accept: dedupe by Idempotency-Key (case-insensitive
+      // header lookup against the LOWERCASED `req.headers` — this is
+      // explicitly the "apply side" of the idempotency contract; the
+      // assertion of the *casing* on the wire is done elsewhere
+      // against `rawHeaders`).
+      if (url === "/api/murmur/accept") {
+        const idemKey = req.headers["idempotency-key"];
+        if (typeof idemKey === "string") {
+          appliedKeys.add(idemKey);
+        }
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      // Default: stub envelope.
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(defaultStubBody(url)));
+    });
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, "127.0.0.1", () => {
+      resolve();
+    }),
+  );
+
+  const addr = server.address() as AddressInfo;
+  const origin = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    origin,
+    received,
+    acceptApplyCount: () => appliedKeys.size,
+    seenIdempotencyKeys: () => Array.from(appliedKeys),
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        // Force-close any kept-alive sockets so the test process can
+        // exit promptly; the dispatcher's undici `Pool` keeps connections
+        // alive between calls.
+        server.closeAllConnections?.();
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+/**
+ * Helper: extract the value of a header from a raw-headers array,
+ * preserving the case of the matched name. Returns null if no entry
+ * matches `name` case-insensitively.
+ *
+ * The integration test uses this twice — once to assert the matched
+ * name's casing equals the M0 constant, and once to read the value.
+ */
+export function findRawHeader(
+  rawHeaders: ReadonlyArray<string>,
+  name: string,
+): { readonly nameOnWire: string; readonly value: string } | null {
+  const lower = name.toLowerCase();
+  for (let i = 0; i + 1 < rawHeaders.length; i += 2) {
+    const k = rawHeaders[i];
+    const v = rawHeaders[i + 1];
+    if (k === undefined || v === undefined) continue;
+    if (k.toLowerCase() === lower) {
+      return { nameOnWire: k, value: v };
+    }
+  }
+  return null;
+}

--- a/src/integration/scripted-agent.ts
+++ b/src/integration/scripted-agent.ts
@@ -1,0 +1,346 @@
+/**
+ * Scripted "agent" loop for the integration test.
+ *
+ * No LLM. The loop walks `pull_task` → optionally `task_tool` per
+ * subtask's declared subcommands → `submit_result` until `pull_task`
+ * returns `data: null`. For each subtask id, the loop knows what shape
+ * to construct as a valid result so the M0 schema validator inside the
+ * CAS submit handler accepts it.
+ *
+ * The MCP `task_tool` tool itself is still a stub (M6's
+ * `not_implemented` placeholder). To exercise the cross-repo wire
+ * contract under test by issue #35, we call `dispatchTaskTool` directly
+ * with the same DB + bearer the production wiring uses. That keeps the
+ * test focused on the wire-level contract (request headers + envelope
+ * shape against the mock-jobseek) rather than tunnelling through MCP's
+ * transport layer, which is covered separately by `src/mcp/server.test.ts`.
+ *
+ * The loop also asserts envelope shape on every response from the
+ * agent app — every body MUST be `{ ok, errors?, data? }` with no
+ * `accepted` key. The assertions live in the integration test file
+ * itself (so a failure points at the test source, not this helper);
+ * this module exposes the raw responses so the test can drive them.
+ */
+
+import type Database from "better-sqlite3";
+import type { Hono } from "hono";
+
+import type { EnvelopeResponse } from "@murmur/contracts-types";
+
+import { dispatchTaskTool } from "../dispatch/task_tool.js";
+
+/**
+ * Result of one `pull_task` call. Mirrors the agent app's envelope.
+ */
+export type PullTaskResponse = EnvelopeResponse<PullTaskData | null>;
+
+/**
+ * Shape of `data` returned by `GET /work/next` on success. Subset of
+ * `NextWorkData` from `src/api/agent/work.ts`.
+ */
+export interface PullTaskData {
+  readonly instructions: string;
+  readonly input: unknown;
+  readonly output_schema: Readonly<Record<string, unknown>>;
+  readonly claim: string;
+}
+
+/**
+ * Result of a `task_tool` invocation, surfaced verbatim from the
+ * dispatcher.
+ */
+export type TaskToolResponse = EnvelopeResponse<unknown>;
+
+/**
+ * Result of a `submit_result` call. Mirrors the agent app's envelope.
+ */
+export type SubmitResultResponse = EnvelopeResponse<{ run_id: string }>;
+
+/**
+ * Options accepted by {@link runScriptedAgent}.
+ */
+export interface RunScriptedAgentOptions {
+  /** The Murmur Hono app — created via `createServer({ token, db })`. */
+  readonly app: Hono;
+  /** Open SQLite handle the app is bound to. The dispatcher needs this. */
+  readonly db: Database.Database;
+  /** The `MURMUR_TOKEN` value used as Bearer for both Murmur AND the proxy. */
+  readonly bearer: string;
+  /**
+   * `boards` shape returned by `list-boards`. The 1-board test passes a
+   * single-element array; the 3-board test passes three. Each element
+   * must satisfy the pipeline's `boards` item schema (alias, url,
+   * provider).
+   */
+  readonly boards: ReadonlyArray<BoardSpec>;
+  /**
+   * Optional record of every `task_tool` call made during the run.
+   * Tests use it to assert each envelope's shape.
+   */
+  readonly taskToolCalls?: TaskToolResponse[];
+  /**
+   * Optional record of every `pull_task` and `submit_result` envelope.
+   */
+  readonly murmurCalls?: EnvelopeResponse<unknown>[];
+}
+
+/**
+ * One board element returned by `list-boards`.
+ */
+export interface BoardSpec {
+  readonly alias: string;
+  readonly url: string;
+  readonly provider: string;
+}
+
+/**
+ * Outcome of {@link runScriptedAgent}. The `runId` is the run the agent
+ * worked through (multiple runs would not happen in our tests, but we
+ * surface the id so the caller can read `runs.final_output_json`
+ * directly when needed).
+ */
+export interface RunScriptedAgentResult {
+  readonly runId: string;
+  readonly claimedSubtaskOrder: ReadonlyArray<{
+    readonly subtaskId: string;
+    readonly input: unknown;
+  }>;
+}
+
+const AUTH_HEADER_NAME = "Authorization";
+
+/**
+ * Drive the scripted agent loop. Returns when `pull_task` reports an
+ * empty queue (`data: null`). Throws on any envelope shape mismatch
+ * (those are programmer-error against the agent app, not legitimate
+ * agent failure paths) so the test's outer `await` surfaces a descriptive
+ * stack.
+ *
+ * For each claim:
+ *
+ *   - **`pre-verify`** — invokes `task_tool('verify company')`, then
+ *     submits `{ verified: true, canonical_name, canonical_website }`.
+ *   - **`list-boards`** — invokes `task_tool('analyze hreflang')` once,
+ *     then submits `{ boards: <opts.boards> }`.
+ *   - **`configure-board`** — invokes `task_tool('probe monitor')`,
+ *     `task_tool('select monitor')`, `task_tool('run monitor')`,
+ *     `task_tool('feedback')` in order, then submits
+ *     `{ outcome: 'configured', monitor_type: 'rss', ... }`.
+ *
+ * Every `task_tool` call is asserted to have `ok === true` (we use
+ * stub publishers that always return 200). On unexpected envelope
+ * shapes the loop throws with a message naming the violated contract
+ * — the issue's quality gate "Failure messages say which contract was
+ * violated" applies here.
+ */
+export async function runScriptedAgent(
+  options: RunScriptedAgentOptions,
+): Promise<RunScriptedAgentResult> {
+  const claimed: Array<{ subtaskId: string; input: unknown }> = [];
+  let runId = "";
+
+  // Loop bound: a 3-board run goes pre-verify (1) + list-boards (1) +
+  // configure-board × 3 = 5 claims. We bound at 32 to catch infinite
+  // loops without trusting the test's expected count.
+  for (let iter = 0; iter < 32; iter += 1) {
+    const claim = await pullTask(options.app, options.bearer);
+    if (options.murmurCalls !== undefined) {
+      options.murmurCalls.push(claim);
+    }
+    if (!claim.ok) {
+      throw new Error(
+        `pull_task envelope was not ok at iteration ${iter}: errors=${JSON.stringify(claim.errors)}`,
+      );
+    }
+    if (claim.data === null) {
+      // Empty queue → loop is done.
+      return { runId, claimedSubtaskOrder: claimed };
+    }
+
+    const data = claim.data;
+
+    // Resolve the claim row to learn the subtask_id (the data envelope
+    // doesn't carry it directly — `instructions` is a free-text field).
+    // We look it up on the DB by claim_token; this is purely a test
+    // affordance, not part of the contract.
+    const lookup = options.db
+      .prepare(
+        `SELECT subtask_id, run_id FROM subtask_instances WHERE claim_token = ?`,
+      )
+      .get(data.claim) as
+      | { subtask_id: string; run_id: string }
+      | undefined;
+    if (lookup === undefined) {
+      throw new Error(
+        `claim_token ${data.claim} did not resolve to a subtask_instance row`,
+      );
+    }
+    runId = lookup.run_id;
+    const subtaskId = lookup.subtask_id;
+    claimed.push({ subtaskId, input: data.input });
+
+    // Per-subtask: invoke the appropriate subcommands then submit.
+    let result: unknown;
+    switch (subtaskId) {
+      case "pre-verify": {
+        const verify = await taskTool(
+          options.db,
+          options.bearer,
+          data.claim,
+          "verify company",
+          { website: "https://example.com" },
+        );
+        if (options.taskToolCalls !== undefined) {
+          options.taskToolCalls.push(verify);
+        }
+        if (!verify.ok) {
+          throw new Error(
+            `task_tool('verify company') was not ok: ${JSON.stringify(verify.errors)}`,
+          );
+        }
+        result = {
+          verified: true,
+          canonical_name: "Example, Inc.",
+          canonical_website: "https://example.com",
+        };
+        break;
+      }
+      case "list-boards": {
+        const probe = await taskTool(
+          options.db,
+          options.bearer,
+          data.claim,
+          "analyze hreflang",
+          { website: "https://example.com" },
+        );
+        if (options.taskToolCalls !== undefined) {
+          options.taskToolCalls.push(probe);
+        }
+        if (!probe.ok) {
+          throw new Error(
+            `task_tool('analyze hreflang') was not ok: ${JSON.stringify(probe.errors)}`,
+          );
+        }
+        result = { boards: options.boards };
+        break;
+      }
+      case "configure-board": {
+        for (const sub of [
+          ["probe monitor", { board_url: "x", expected_count: 10 }] as const,
+          ["select monitor", { type: "rss", name: "cfg-1", config: {} }] as const,
+          ["run monitor", { config: "cfg-1" }] as const,
+          ["feedback", { verdict: "good", per_field: {} }] as const,
+        ]) {
+          const r = await taskTool(
+            options.db,
+            options.bearer,
+            data.claim,
+            sub[0],
+            sub[1],
+          );
+          if (options.taskToolCalls !== undefined) {
+            options.taskToolCalls.push(r);
+          }
+          if (!r.ok) {
+            throw new Error(
+              `task_tool('${sub[0]}') was not ok: ${JSON.stringify(r.errors)}`,
+            );
+          }
+        }
+        result = {
+          outcome: "configured",
+          monitor_type: "rss",
+          monitor_config: { url: "https://example.com/rss" },
+          verdict: "good",
+        };
+        break;
+      }
+      default:
+        throw new Error(`scripted agent has no script for subtask ${subtaskId}`);
+    }
+
+    const submit = await submitResult(
+      options.app,
+      options.bearer,
+      data.claim,
+      result,
+    );
+    if (options.murmurCalls !== undefined) {
+      options.murmurCalls.push(submit);
+    }
+    if (!submit.ok) {
+      throw new Error(
+        `submit_result for ${subtaskId} was not ok: ${JSON.stringify(submit.errors)}`,
+      );
+    }
+  }
+
+  throw new Error(
+    "scripted agent ran for 32 iterations without exhausting the queue — likely a loop bug",
+  );
+}
+
+/**
+ * Issue `GET /work/next` against the in-process Murmur app. Returns
+ * the parsed envelope verbatim.
+ */
+export async function pullTask(
+  app: Hono,
+  bearer: string,
+): Promise<PullTaskResponse> {
+  const response = await app.request("/work/next", {
+    method: "GET",
+    headers: { [AUTH_HEADER_NAME]: `Bearer ${bearer}` },
+  });
+  return (await response.json()) as PullTaskResponse;
+}
+
+/**
+ * Issue `POST /work/{claim}/result` against the in-process Murmur app.
+ */
+export async function submitResult(
+  app: Hono,
+  bearer: string,
+  claim: string,
+  result: unknown,
+  notes?: string,
+): Promise<SubmitResultResponse> {
+  const body: { result: unknown; notes?: string } = { result };
+  if (notes !== undefined) body.notes = notes;
+  const response = await app.request(
+    `/work/${encodeURIComponent(claim)}/result`,
+    {
+      method: "POST",
+      headers: {
+        [AUTH_HEADER_NAME]: `Bearer ${bearer}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  return (await response.json()) as SubmitResultResponse;
+}
+
+/**
+ * Invoke a `task_tool` subcommand against the dispatcher directly.
+ * Production routes the same call through the MCP transport, but the
+ * dispatcher itself is the seam under test by the cross-repo wire
+ * contract — it is what emits the `Authorization` /
+ * `X-Murmur-Subcommand` / `X-Murmur-Claim-Token` headers the integration
+ * test asserts on against the mock-jobseek.
+ */
+export async function taskTool(
+  db: Database.Database,
+  bearer: string,
+  claimToken: string,
+  subcommand: string,
+  args: unknown,
+): Promise<TaskToolResponse> {
+  return dispatchTaskTool({
+    db,
+    bearer,
+    claimToken,
+    subcommand,
+    args,
+  });
+}

--- a/src/integration/scripted-agent.ts
+++ b/src/integration/scripted-agent.ts
@@ -152,12 +152,15 @@ export async function runScriptedAgent(
         `pull_task envelope was not ok at iteration ${iter}: errors=${JSON.stringify(claim.errors)}`,
       );
     }
-    if (claim.data === null) {
-      // Empty queue → loop is done.
+    if (claim.data === undefined || claim.data === null) {
+      // Empty queue → loop is done. (`data === null` is the empty
+      // queue per M5; `data === undefined` would be a type-shape miss
+      // we never expect at runtime but the discriminated-union type
+      // permits.)
       return { runId, claimedSubtaskOrder: claimed };
     }
 
-    const data = claim.data;
+    const data: PullTaskData = claim.data;
 
     // Resolve the claim row to learn the subtask_id (the data envelope
     // doesn't carry it directly — `instructions` is a free-text field).


### PR DESCRIPTION
## Summary

Adds the I1 cross-repo integration test (`src/integration/full-flow.test.ts`)
that exercises the full Murmur stack end-to-end against a stub jobseek
publisher running on a local socket. The test boots an in-process
Murmur server (with `bearerAuth` + `createPublisherApp` +
`createAgentApp` + `createMcpRoute` composed identically to
`src/server.ts`) and a `node:http` mock-jobseek on `127.0.0.1:0` that
records every request's `req.rawHeaders` so the M0 wire-cased header
constants can be asserted exactly.

## Related issue

Closes colophon-group/murmur#35

## Files changed (high-level)

- `src/integration/README.md` — explains the directory's purpose and
  why these tests live separate from per-module tests.
- `src/integration/fixtures/jobseek-pipeline.ts` — DESIGN.md §3.1
  pipeline def builder, parameterised on `apiBase` + `webhookUrl` so it
  points at the test's mock origin.
- `src/integration/mock-jobseek.ts` — stub publisher HTTP server.
  Captures `rawHeaders` verbatim and exposes a `seenIdempotencyKeys()`
  / `acceptApplyCount()` pair so the webhook-replay assertion can
  prove the apply side-effect is idempotent.
- `src/integration/scripted-agent.ts` — non-LLM scripted agent loop
  driving `pull_task` → `task_tool` per-subtask → `submit_result`.
- `src/integration/full-flow.test.ts` — 8 assertions covering every
  bullet of issue #35's Verification list.

## Verification (from the issue)

- [x] Happy path single-board run completes
- [x] 3-board spawn run completes; all 3 children claimed in `created_at` order
- [x] `task_tool` envelope stays M0-shaped across all routes
- [x] Header casing matches M0 constants (asserted via `req.rawHeaders`)
- [x] Mock-jobseek receives bearer with `MURMUR_TOKEN` on every proxied call
- [x] Webhook bearer + `Idempotency-Key` visible in mock-jobseek's accept handler
- [x] Replay of webhook does not re-trigger the apply side-effect
- [x] No `accepted` key appears in any response or webhook body (strict regex check)

## Manual checks run locally

- `pnpm typecheck` passes
- `pnpm lint` passes
- `pnpm test` passes (285 + 34 tests, 8 are this file)
- `pnpm grep:all` passes
- `pnpm build` passes

## Notes for reviewer

- **Pipeline def is seeded directly into `pipelines` rather than via `POST /pipelines`.** The M0 schema regex pins `endpoint` to `^POST https://` and `webhook` to `^https://`. The mock-jobseek runs on plain `http://127.0.0.1:<port>`; spinning up a self-signed TLS server in a CI test would balloon scope without adding to the wire-contract assertion. The dispatcher reads `pipelines.def_json` verbatim from the DB, so seeding it directly preserves every M0 contract under test (header casing, envelope shape, idempotency key) while sidestepping the registration regex that has nothing to do with Murmur ↔ jobseek wire fidelity.
- **Pending rows are inserted by the test harness.** The publisher route only inserts the run-start ready set; subtasks with non-empty `requires` need a `pending` row for `markNextReady` to flip to `ready`. The same pattern is in `src/api/agent/agent.test.ts#seedRun`. This isn't fixed here — it would be a separate orthogonal change to `pipelines.ts`.
- **MCP `task_tool` is still a stub** (M6's `not_implemented` handler). The integration test calls `dispatchTaskTool` directly to exercise the wire-level seam under test (header casing, envelope shape against the publisher). The MCP transport itself is covered by `src/mcp/server.test.ts`.
- **Webhook synchronisation.** The harness wraps `deliverWebhook` so the test can `await` first-attempt promises before reading `runs.webhook_status` — production wiring in `src/server.ts` is fire-and-forget, but the harness mirrors the same composition so any drift surfaces here as a test failure.
- **Webhook body shape.** Currently `deliverWebhook` POSTs the composed `final_output` directly as the JSON body (no `{run_id, pipeline_id, ..., final_output}` wrapper). The `WebhookPayload` type in `@murmur/contracts-types` describes a wrapper, but the implementation in `src/webhook.ts` does not produce one. The integration test asserts on the actual implementation; if the wrapper is restored as M10's intended shape, the test's body assertions will need to be updated too.