### PR TITLE
docs(contracts): reconcile webhook body shape — naked final_output, no wrapper

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -292,6 +292,14 @@ When all subtasks of a run complete, Murmur POSTs the composed
 
 ### 6.1 Request
 
+The HTTP body **is** the composed `final_output` — no envelope, no
+wrapper around it. Per-run metadata travels in headers:
+
+- `Authorization: Bearer <MURMUR_TOKEN>` — same token as everywhere else.
+- `Idempotency-Key: <run_id>` — stable run identifier; the publisher
+  dedupes on this key (see §6.3).
+- `Content-Type: application/json`.
+
 ```
 POST /api/murmur/accept HTTP/1.1
 Host: jobseek.colophon-group.org
@@ -299,14 +307,16 @@ Authorization: Bearer Z2hzX01VUk1VUl9ERU1PXzAxX1RPS0VOX1ZBTFVF
 Idempotency-Key: r_8a91d4
 Content-Type: application/json
 
-{
-  "run_id": "r_8a91d4",
-  "pipeline_id": "jobseek-add-company",
-  "pipeline_version": 7,
-  "completed_at": "2026-04-29T11:07:40.123Z",
-  "final_output": { /* §7 */ }
-}
+{ /* the composed final_output — see §7 for the composition rules and
+     a worked example. Keys are pipeline-specific. */ }
 ```
+
+The TS type `WebhookPayload` (in `@murmur/contracts-types`) names the
+body as `Readonly<Record<string, unknown>>` — its concrete shape is
+determined by the pipeline def's `final_output.composes`. If future
+publishers need additional metadata (pipeline id, version, completion
+timestamp), surface it as `X-Murmur-*` headers — never nest it inside
+the body.
 
 ### 6.2 Auth
 

--- a/docs/contracts.py
+++ b/docs/contracts.py
@@ -109,17 +109,17 @@ WEBHOOK_RETRY_DELAY_MS: Final[int] = 30_000
 WEBHOOK_DEDUPE_WINDOW_MS: Final[None] = None  # durable on writer side
 
 
-@dataclass(frozen=True)
-class WebhookPayload:
-    """Body of the webhook POST. Headers (Authorization, Idempotency-Key,
-    Content-Type) are not part of this dataclass — they are set on the
-    HTTP request directly."""
-
-    run_id: str
-    pipeline_id: str
-    pipeline_version: int
-    completed_at: str
-    final_output: Mapping[str, Any]
+# The webhook body is the composed `final_output` directly — no
+# envelope, no wrapper. Per-run metadata travels in headers
+# (`Authorization`, `Idempotency-Key`, `Content-Type`). See
+# `docs/contracts.md` §6.1.
+#
+# `WebhookPayload` is a type alias (not a dataclass) because the body's
+# concrete shape is determined by the pipeline def's `final_output.composes`
+# and varies per pipeline. The previous wrapper dataclass was a spec
+# drift — the shipped sender (`src/webhook.ts`) never emitted that
+# shape; reconciled in issue #63.
+WebhookPayload = Mapping[str, Any]
 
 
 # ---------------------------------------------------------------------------

--- a/docs/contracts/fixtures/all-seven.json
+++ b/docs/contracts/fixtures/all-seven.json
@@ -153,39 +153,34 @@
   },
 
   "6_webhook": {
+    "_comment": "Body is the composed final_output directly — no wrapper. run_id travels in the Idempotency-Key header.",
     "headers": {
       "Authorization": "Bearer Z2hzX01VUk1VUl9ERU1PXzAxX1RPS0VOX1ZBTFVFXzAxMjM0NTY3OA",
       "Idempotency-Key": "r_8a91d4",
       "Content-Type": "application/json"
     },
     "body": {
-      "run_id": "r_8a91d4",
-      "pipeline_id": "jobseek-add-company",
-      "pipeline_version": 7,
-      "completed_at": "2026-04-29T11:07:40.123Z",
-      "final_output": {
-        "canonical_name": "ExampleCo",
-        "canonical_website": "https://example.co",
-        "slug": "exampleco",
-        "description": "Example company.",
-        "industry_ids": ["software", "saas"],
-        "boards": [
-          {
-            "alias": "careers",
-            "board_url": "https://job-boards.greenhouse.io/exampleco",
-            "provider": "greenhouse",
-            "outcome": "configured",
-            "monitor_type": "greenhouse",
-            "monitor_config": { "token": "exampleco" },
-            "scraper_type": "greenhouse",
-            "scraper_config": {},
-            "verdict": "ok",
-            "per_field": {}
-          }
-        ],
-        "kb_entries": [],
-        "case_studies": []
-      }
+      "canonical_name": "ExampleCo",
+      "canonical_website": "https://example.co",
+      "slug": "exampleco",
+      "description": "Example company.",
+      "industry_ids": ["software", "saas"],
+      "boards": [
+        {
+          "alias": "careers",
+          "board_url": "https://job-boards.greenhouse.io/exampleco",
+          "provider": "greenhouse",
+          "outcome": "configured",
+          "monitor_type": "greenhouse",
+          "monitor_config": { "token": "exampleco" },
+          "scraper_type": "greenhouse",
+          "scraper_config": {},
+          "verdict": "ok",
+          "per_field": {}
+        }
+      ],
+      "kb_entries": [],
+      "case_studies": []
     },
     "retry_count": 1,
     "retry_delay_ms": 30000,

--- a/docs/contracts/fixtures/check_python.py
+++ b/docs/contracts/fixtures/check_python.py
@@ -94,16 +94,21 @@ def main() -> int:
         assert isinstance(e, c.ValidationError)
         assert e.path == "" or e.path.startswith("/")
 
-    # §6 — webhook payload + headers
+    # §6 — webhook payload + headers.
+    # Body IS the composed final_output (no wrapper). run_id rides on
+    # the Idempotency-Key header. WebhookPayload is a Mapping alias.
     w = blob["6_webhook"]
-    payload = c.WebhookPayload(
-        run_id=w["body"]["run_id"],
-        pipeline_id=w["body"]["pipeline_id"],
-        pipeline_version=w["body"]["pipeline_version"],
-        completed_at=w["body"]["completed_at"],
-        final_output=w["body"]["final_output"],
-    )
-    assert w["headers"][c.HEADER_IDEMPOTENCY_KEY] == payload.run_id
+    payload: c.WebhookPayload = w["body"]
+    assert isinstance(payload, dict)
+    # Composed fields land at the top level of the body.
+    assert "canonical_name" in payload
+    assert "boards" in payload
+    # No legacy wrapper fields leak into the body.
+    assert "run_id" not in payload
+    assert "pipeline_id" not in payload
+    assert "final_output" not in payload, "body must not nest final_output under a wrapper"
+    # run_id travels as the Idempotency-Key header.
+    assert w["headers"][c.HEADER_IDEMPOTENCY_KEY].startswith("r_")
     assert w["headers"][c.HEADER_AUTHORIZATION].startswith(c.BEARER_PREFIX)
     assert w["retry_count"] == c.WEBHOOK_RETRY_COUNT
     assert w["retry_delay_ms"] == c.WEBHOOK_RETRY_DELAY_MS

--- a/packages/contracts-types/src/webhook.ts
+++ b/packages/contracts-types/src/webhook.ts
@@ -7,33 +7,30 @@
 /**
  * Body of the webhook POST.
  *
- * Headers (set by Murmur, NOT in the body):
+ * The body IS the composed `final_output` directly — no envelope, no
+ * wrapper. Per-run metadata travels in headers, not the body:
+ *
  *   - `Authorization: Bearer <MURMUR_TOKEN>`
  *   - `Idempotency-Key: <run_id>`
  *   - `Content-Type: application/json`
  *
- * `final_output` is the result of applying the pipeline's
- * `final_output.composes` rule to all subtask outputs.
+ * The body's exact shape is determined by the pipeline def's
+ * `final_output.composes` rules (§7) — it is a JSON object whose keys
+ * are pipeline-specific. This type alias names that "naked composed
+ * object" so callers can spell its intent without committing to a
+ * specific pipeline's keys.
+ *
+ * History: an earlier draft of the contract wrapped `final_output`
+ * inside a `{ run_id, pipeline_id, pipeline_version, completed_at,
+ * final_output }` envelope. The shipped sender (`src/webhook.ts`)
+ * never emitted that wrapper, and the receiver (jobseek's accept
+ * handler) was implemented against the naked shape. Issue #63
+ * reconciled the spec to match: the body is the composed object, and
+ * `run_id` is the `Idempotency-Key` header. If the publisher needs
+ * other run metadata in the future, surface it as `X-Murmur-*`
+ * headers — do not nest it inside the body.
  */
-export interface WebhookPayload {
-  /** Stable run identifier; also the value of the `Idempotency-Key` header. */
-  readonly run_id: string;
-
-  /** Pipeline def id (slug) the run was started from. */
-  readonly pipeline_id: string;
-
-  /**
-   * Pipeline-def version the run was pinned to at start. MVP: integer
-   * monotonically incremented on each `POST /pipelines` upsert.
-   */
-  readonly pipeline_version: number;
-
-  /** RFC 3339 / ISO 8601 timestamp, UTC, when Murmur composed the output. */
-  readonly completed_at: string;
-
-  /** Composed final output. Shape determined by the pipeline's `composes` rule. */
-  readonly final_output: Readonly<Record<string, unknown>>;
-}
+export type WebhookPayload = Readonly<Record<string, unknown>>;
 
 /**
  * Response shape the publisher's accept handler MUST return.

--- a/packages/contracts-types/test/fixture.test.ts
+++ b/packages/contracts-types/test/fixture.test.ts
@@ -32,6 +32,8 @@ interface AllSevenFixture {
     errors: ValidationError[];
   };
   "6_webhook": {
+    // Body is the composed final_output directly — no wrapper. The
+    // type alias `WebhookPayload` names this naked shape.
     headers: Record<string, string>;
     body: WebhookPayload;
     retry_count: number;
@@ -126,22 +128,32 @@ describe("docs/contracts/fixtures/all-seven.json", () => {
     }
   });
 
-  it("§6 — webhook idempotency key matches run_id", () => {
+  it("§6 — webhook headers carry run_id and bearer; constants match spec", () => {
     const w = fixture["6_webhook"];
-    expect(w.headers["Idempotency-Key"]).toBe(w.body.run_id);
+    // run_id travels as the Idempotency-Key header (NOT in the body).
+    expect(w.headers["Idempotency-Key"]).toMatch(/^r_/);
     expect(w.headers["Authorization"]).toMatch(/^Bearer /);
+    expect(w.headers["Content-Type"]).toBe("application/json");
     expect(w.retry_count).toBe(1);
     expect(w.retry_delay_ms).toBe(30_000);
     expect(w.dedupe_window_ms).toBeNull();
   });
 
-  it("§6 — webhook body is a WebhookPayload", () => {
+  it("§6 — webhook body is the composed final_output directly (no wrapper)", () => {
     const w = fixture["6_webhook"];
-    expect(w.body.run_id).toBeDefined();
-    expect(w.body.pipeline_id).toBe("jobseek-add-company");
-    expect(typeof w.body.pipeline_version).toBe("number");
-    expect(w.body.completed_at).toMatch(/Z$/);
-    expect(typeof w.body.final_output).toBe("object");
+    // The body IS the composed object: keys come from the pipeline's
+    // `final_output.composes` rules, not a fixed envelope.
+    expect(typeof w.body).toBe("object");
+    expect(w.body).not.toBeNull();
+    expect(w.body["canonical_name"]).toBe("ExampleCo");
+    expect(Array.isArray(w.body["boards"])).toBe(true);
+    // The legacy wrapper fields MUST NOT appear at the body's top level.
+    // They were the spec drift this fixture used to encode.
+    expect(w.body["run_id"]).toBeUndefined();
+    expect(w.body["pipeline_id"]).toBeUndefined();
+    expect(w.body["pipeline_version"]).toBeUndefined();
+    expect(w.body["completed_at"]).toBeUndefined();
+    expect(w.body["final_output"]).toBeUndefined();
   });
 
   it("§7 — composes fixture covers wildcard, prefix, rename, cartesian, flatten", () => {


### PR DESCRIPTION
## Summary
The shipped webhook sender (`src/webhook.ts`) POSTs the composed `final_output` directly as the JSON body, with `Authorization`, `Idempotency-Key`, and `Content-Type` carried as headers. The `WebhookPayload` interface defined a wrapper envelope (`{ run_id, pipeline_id, pipeline_version, completed_at, final_output }`) that no code ever emitted — pure spec drift discovered while reviewing I1 (#35). Per #63 option (2), this PR aligns the spec to the implementation: the body IS the composed `final_output`; metadata travels in headers. P4 (jobseek's accept handler) was already built against this naked shape, so no receiver change is required.

## Related issue
Closes colophon-group/murmur#63

## Files changed (high-level)
- `packages/contracts-types/src/webhook.ts` — `WebhookPayload` is now `Readonly<Record<string, unknown>>`; JSDoc explains the naked-body contract and the migration history (future metadata → `X-Murmur-*` headers, not body envelopes).
- `docs/contracts.md` §6.1 — prose + JSON example reflect the naked body.
- `docs/contracts.py` — `WebhookPayload = Mapping[str, Any]` alias (was a dataclass).
- `docs/contracts/fixtures/all-seven.json` — `6_webhook.body` flattened to the composed object.
- `docs/contracts/fixtures/check_python.py` — assertions updated; explicitly checks the legacy wrapper keys do NOT leak into the body.
- `packages/contracts-types/test/fixture.test.ts` — §6 tests assert `Idempotency-Key` carries `run_id` (header), body has composed fields, and the wrapper keys are absent from the body.

`src/webhook.ts` is unchanged (it is the source of truth).

## Verification
- [x] §6 fixture body is the composed `final_output` directly (test asserts wrapper keys absent)
- [x] §6 headers carry `run_id` via `Idempotency-Key` (test asserts header presence + bearer prefix)
- [x] `WebhookPayload` type is the naked shape and parses the fixture without errors
- [x] Webhook constants (retry count / delay / dedupe window) untouched

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (277 + 34 tests passed)
- `pnpm grep:all` ✓ (`grep-no-accepted-key` etc.)
- `pnpm build` ✓
- `python3 docs/contracts/fixtures/check_python.py` ✓

## Notes for reviewer
- The Python `WebhookPayload` went from a frozen dataclass with five fields to a `Mapping[str, Any]` type alias. The only caller in-repo is `check_python.py`, which is updated. Out-of-repo callers (jobseek crawler) treat `WebhookPayload` as the receiver-side body shape; switching to a Mapping alias is strictly looser, so no break.
- The fixture's old wrapper carried `pipeline_id`, `pipeline_version`, and `completed_at`. None of these are on the wire today and the receiver doesn't need them. If a future publisher does, surface them as `X-Murmur-*` headers (called out in `docs/contracts.md` §6.1) rather than reintroducing a body envelope.
- Naming kept stable: `WebhookPayload` still exists as an exported symbol so downstream imports keep working.