### PR TITLE
ci(workflows): switch GHCR login to GHCR_PAT to bypass org package-creation block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
     timeout-minutes: 15
     needs: quality
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Defensive belt-and-suspenders: the load-bearing fix is the GHCR_PAT swap
+    # below, but declare write:packages here too so workflow-level perms aren't
+    # the surprise blocker if the PAT is ever rotated out.
+    permissions:
+      contents: read
+      packages: write
     concurrency:
       group: build-main
       cancel-in-progress: false
@@ -81,12 +87,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Buildx for ARM64
         uses: docker/setup-buildx-action@v3
+      # Use GHCR_PAT (repo secret) instead of GITHUB_TOKEN: the colophon-group
+      # GitHub App installation is not allowed to *create* new org packages, so
+      # the first push of ghcr.io/colophon-group/murmur fails with
+      # "denied: installation not allowed to Create organization package".
+      # A PAT with write:packages bypasses the install-level block. Username
+      # must be the org (github.repository_owner), not github.actor, because
+      # the PAT belongs to a user/org admin, not the run trigger actor.
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Build & push
         if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
The `build` job's `Login GHCR` step now authenticates with `GHCR_PAT` (repo secret) and `github.repository_owner` instead of `GITHUB_TOKEN` + `github.actor`. The colophon-group GitHub App installation lacks permission to *create* new org packages, so the first push of `ghcr.io/colophon-group/murmur` was failing with `denied: installation not allowed to Create organization package`. A user/admin PAT bypasses the install-level block. Also declares `permissions: { contents: read, packages: write }` at the build-job level as defense-in-depth.

## Related issue
Closes colophon-group/murmur#65

## Files changed (high-level)
- `.github/workflows/ci.yml` - swap `Login GHCR` credentials to `GHCR_PAT` + `github.repository_owner`; add explanatory comments; add job-level `permissions` block.

## Verification (from the issue)
- [x] ci.yml build job logs into GHCR using GHCR_PAT (visible in diff)
- [ ] Push to main produces `ghcr.io/colophon-group/murmur:latest` AND `:<sha>` in GHCR (post-merge - orchestrator verifies)
- [ ] `gh api orgs/colophon-group/packages/container/murmur` returns 200 (post-merge - orchestrator verifies)

## Manual checks run locally
- `python3 -c 'import yaml; yaml.safe_load(open(...))'` -> YAML parses cleanly.
- `pnpm grep:all` -> all gates pass.
- Typecheck/lint/test untouched (no source files changed).

## Notes for reviewer
- The PAT swap is the load-bearing fix; the `permissions:` block is belt-and-suspenders. If the PAT is ever rotated and `GITHUB_TOKEN` is restored, the explicit `packages: write` will at least eliminate workflow-level perms as a possible blocker.
- `github.repository_owner` (= `colophon-group`) is correct because the PAT belongs to a user/admin authorised on the org, not to the run-trigger actor.
- The build job is gated on `push` to `main`, so this PR's CI will only run `quality`; the GHCR login path won't be exercised until merge. The orchestrator will verify the package landing post-merge.