### PR TITLE
fix(ci): revert GHCR login to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,9 @@ jobs:
     timeout-minutes: 15
     needs: quality
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # Defensive belt-and-suspenders: the load-bearing fix is the GHCR_PAT swap
-    # below, but declare write:packages here too so workflow-level perms aren't
-    # the surprise blocker if the PAT is ever rotated out.
+    # Least-privilege workflow perms: the build job needs to push images to
+    # GHCR, nothing else. Kept as belt-and-suspenders even though the actual
+    # auth flows through the credential below.
     permissions:
       contents: read
       packages: write
@@ -87,19 +87,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Buildx for ARM64
         uses: docker/setup-buildx-action@v3
-      # Use GHCR_PAT (repo secret) instead of GITHUB_TOKEN: the colophon-group
-      # GitHub App installation is not allowed to *create* new org packages, so
-      # the first push of ghcr.io/colophon-group/murmur fails with
-      # "denied: installation not allowed to Create organization package".
-      # A PAT with write:packages bypasses the install-level block. Username
-      # must be the org (github.repository_owner), not github.actor, because
-      # the PAT belongs to a user/org admin, not the run trigger actor.
+      # GITHUB_TOKEN works for *Update* once the package exists. The one-time
+      # first push that *Creates* the package requires either an org admin to
+      # pre-create via the GitHub Packages dashboard, OR a PAT with
+      # write:packages. Tracked separately — out of scope for CI's credential.
+      # Mirrors jobseek's working pattern: CI builds with GITHUB_TOKEN (push),
+      # box pulls with a read-only PAT.
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build & push
         if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Reverts PR #66's auth swap. The `GHCR_PAT` repo secret (re-using jobseek's `HETZNER_GH_TOKEN`) only carries `read:packages`, so `docker push` returns `denied: denied`. Restore jobseek's working pattern: CI pushes with `GITHUB_TOKEN`; the box pulls with the read-only PAT.

## Related issue
Follow-up to colophon-group/murmur#65 / #66.

## Files changed (high-level)
- `.github/workflows/ci.yml` — `Login GHCR` step's `username` reverted to `${{ github.actor }}`, `password` to `${{ secrets.GITHUB_TOKEN }}`. Replaced the GHCR_PAT-rationale comment with one that records the residual gotcha. Kept the `permissions: { contents: read, packages: write }` block as least-privilege hygiene.

## Why this works
- `GITHUB_TOKEN` is allowed to **Update** an existing GHCR package owned by the repo's org.
- The remaining org-level "first **Create**" block is operator-bound: the user pre-creates the package via the GitHub Packages dashboard (or an org admin issues a `write:packages` PAT for that one-time push). Tracked separately — out of scope for CI's credential.
- Mirrors jobseek's CI exactly, which has been pushing to GHCR successfully.

## Verification
- N/a — this is a credential-only change; will be exercised by the next push to `main` once the package is pre-created.
- The change is a literal revert of two YAML lines plus a comment block; diff was reviewed against #66's diff.

## Notes for reviewer
The `permissions:` block from #66 is intentionally kept. It is good least-privilege hygiene and orthogonal to the credential choice; removing it would broaden the default token scope unnecessarily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)