### PR TITLE
fix(ci): switch GHCR login back to GHCR_PAT (now write-capable)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Buildx for ARM64
         uses: docker/setup-buildx-action@v3
-      # GITHUB_TOKEN works for *Update* once the package exists. The one-time
-      # first push that *Creates* the package requires either an org admin to
-      # pre-create via the GitHub Packages dashboard, OR a PAT with
-      # write:packages. Tracked separately — out of scope for CI's credential.
-      # Mirrors jobseek's working pattern: CI builds with GITHUB_TOKEN (push),
-      # box pulls with a read-only PAT.
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # PAT-based login: GITHUB_TOKEN's GH App installation cannot Create
+          # new org packages on first push. The PAT belongs to a user with
+          # write:packages scope on the org and bypasses that block.
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Build & push
         if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
Re-apply PR #66's swap of the `build` job's GHCR login from `GITHUB_TOKEN` to `GHCR_PAT`. The PAT now has `write:packages` scope (rotated post-#67), so the org's installation-level block on Create-package no longer applies.

## History
1. **PR #66** — Swapped to `GHCR_PAT` to bypass the colophon-group GH App installation's block on Create-package. Merged.
2. **PR #67** — Reverted to `GITHUB_TOKEN` because the PAT in `GHCR_PAT` at the time was jobseek's `HETZNER_GH_TOKEN`, which only had `read:packages`. Push failed with `denied: denied`. Merged to unbreak.
3. **This PR** — Orchestrator has rotated `GHCR_PAT` (both repo-level and `production`-env-level) to a user PAT with `write:packages` on the org. Re-apply the swap so the next push to `main` can Create the package.

## Files changed
- `.github/workflows/ci.yml` — `build` job's `Login GHCR` step now uses `github.repository_owner` + `secrets.GHCR_PAT`. Comment refreshed to explain the PAT rationale (no longer references `GITHUB_TOKEN`). The `permissions: { contents: read, packages: write }` block on the build job is preserved.

## Related issue
Closes colophon-group/murmur#65 (verification: `gh api orgs/colophon-group/packages/container/murmur` returns 200 after merge).

## Verification
The `build` job is `push`-to-`main` only, so this PR's CI run will exercise only `quality`. The actual GHCR push happens after merge. Orchestrator will check `gh api orgs/colophon-group/packages/container/murmur` post-merge.

## Notes for reviewer
- One file, one step. No code logic changes.
- `permissions: { packages: write }` is intentionally retained as belt-and-suspenders even though the PAT bypasses workflow-level perms — keeps the fallback path uncrippled if the PAT is ever rotated out again.