### PR TITLE
fix(ci): bypass docker/login-action GHCR probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
         # /token?service=ghcr.io). Stdin keeps the PAT off argv. The
         # downstream docker/build-push-action@v5 reads credentials from
         # ~/.docker/config.json written here.
-        run: echo "$GHCR_PAT" | docker login ghcr.io -u "$OWNER" --password-stdin
+        # Username is the PAT owner's GitHub login (viktor-shcherb), NOT the
+        # org name. The package lives under colophon-group/ but the docker
+        # login presents the user's identity; the registry then checks that
+        # user's perms against the org package on subsequent push.
+        run: echo "$GHCR_PAT" | docker login ghcr.io -u viktor-shcherb --password-stdin
         env:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
           OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,16 @@ jobs:
       - name: Buildx for ARM64
         uses: docker/setup-buildx-action@v3
       - name: Login GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          # PAT-based login: GITHUB_TOKEN's GH App installation cannot Create
-          # new org packages on first push. The PAT belongs to a user with
-          # write:packages scope on the org and bypasses that block.
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+        # Direct docker login bypasses docker/login-action@v3's auth probe,
+        # which fails our classic-PAT setup with `denied: denied` even though
+        # the registry's standard token-exchange flow works (verified via
+        # /token?service=ghcr.io). Stdin keeps the PAT off argv. The
+        # downstream docker/build-push-action@v5 reads credentials from
+        # ~/.docker/config.json written here.
+        run: echo "$GHCR_PAT" | docker login ghcr.io -u "$OWNER" --password-stdin
+        env:
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+          OWNER: ${{ github.repository_owner }}
       - name: Build & push
         if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,6 @@ jobs:
         run: echo "$GHCR_PAT" | docker login ghcr.io -u viktor-shcherb --password-stdin
         env:
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
-          OWNER: ${{ github.repository_owner }}
       - name: Build & push
         if: hashFiles('Dockerfile') != ''
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
`docker/login-action@v3` keeps returning `denied: denied` against GHCR with our classic-PAT setup, even though plain `docker login` on the Hetzner box succeeds with the same PAT and the registry's standard `/token?service=ghcr.io` exchange works. The action's internal auth probe is incompatible with our setup.

This PR replaces the action with a direct `run:` step that pipes the PAT into `docker login --password-stdin` (secret stays off argv). `docker/build-push-action@v5` downstream picks up creds from `~/.docker/config.json` written here.

## Related issue
Closes colophon-group/murmur#65 (fix-forward — the prior action-based approach in #65 didn't work in practice).

## Files changed (high-level)
- `.github/workflows/ci.yml` — swap `Login GHCR` action step for a direct `run:` block; `permissions: { contents: read, packages: write }` retained.

## Verification (from the issue)
- [x] PR CI: `quality` job runs on this PR (build is push-to-main only)
- [ ] Post-merge: `build` job completes on main
- [ ] Post-merge: `gh api orgs/colophon-group/packages/container/murmur` returns 200

## Manual checks run locally
- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓
- `pnpm grep:all` ✓ (via `bash scripts/grep-all.sh`)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` ✓

## Notes for reviewer
- Stdin (`--password-stdin`) is the documented way to keep the PAT off argv per Docker's CLI docs.
- `docker/build-push-action@v5` reads from `~/.docker/config.json` by default when no `username/password` inputs supplied — same path jobseek's CI uses successfully.
- Real verification is post-merge since `build` only runs on push-to-main.