### PR TITLE
fix(build): include docs/contracts in image (pipeline-def schema)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,8 +26,22 @@ coverage/
 .turbo/
 .next/
 
-# Docs (not needed in runtime image; reduce attack surface and image size)
+# Docs (not needed in runtime image; reduce attack surface and image size).
+#
+# Exception — docs/contracts/pipeline-def.schema.json is loaded at runtime
+# by src/api/publisher/schema.ts (M0 boundary contract; POST /pipelines body
+# validation). Without it the container crashes on boot with
+# `ENOENT … docs/contracts/pipeline-def.schema.json` because the builder's
+# `COPY . .` honours .dockerignore. Cascading re-includes follow Docker's
+# canonical "exclude parent, re-include specific child" pattern: each parent
+# along the path must be un-excluded before its child can be re-included.
+# Sibling files (docs/*.md, docs/contracts/fixtures/) remain excluded.
 docs/
+!docs/
+docs/*
+!docs/contracts/
+docs/contracts/*
+!docs/contracts/pipeline-def.schema.json
 *.md
 !README.md
 


### PR DESCRIPTION
## Summary

The deployed murmur container crashed on boot with:

```
Error: ENOENT: no such file or directory, open '/app/docs/contracts/pipeline-def.schema.json'
    at readFileSync (node:fs:440:20)
    at loadPipelineDefSchema (/app/src/api/publisher/schema.ts:38:15)
```

`src/api/publisher/schema.ts` (M0 boundary contract — POST /pipelines body validation) loads the JSON Schema synchronously at module import via `readFileSync`. The Dockerfile builder's `COPY . .` honours `.dockerignore`, where `docs/` was excluded wholesale, so the schema never made it into either build stage.

**Fix:** re-include only `docs/contracts/pipeline-def.schema.json` via Docker's canonical "exclude parent, re-include specific child" cascade. Sibling files (`docs/*.md`, `docs/contracts/fixtures/`) stay excluded — they aren't needed at runtime.

Single-file change to `.dockerignore`. The Dockerfile itself didn't need to change: the existing `COPY --from=builder --chown=node:node /app /app` already pulls everything carried through `.dockerignore` into the runtime stage.

## Files changed

- `.dockerignore` — cascading re-include for `docs/contracts/pipeline-def.schema.json`; comment explaining the M0 dependency.

## Verification

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — 285 + 34 tests pass, coverage gate met
- [x] `pnpm grep:all` — all gates pass
- [x] `.dockerignore` matcher simulation (fnmatch) — confirms `docs/contracts/pipeline-def.schema.json` is INCLUDED while `docs/contracts/fixtures/*`, `docs/*.md`, and `docs/contracts.py` remain IGNORED
- [ ] Real `docker buildx build --platform=linux/arm64` — local Docker daemon (colima) wouldn't start on this host; CI will exercise the actual build + push path

## Other related missing paths

Spot-checked `@murmur/contracts-types`: its `package.json` exports raw `.ts` from `packages/contracts-types/src/` (no `dist/`, runtime uses `tsx`), and `packages/` is not excluded by `.dockerignore` and is part of the builder's `COPY . .`. Confirmed accessible at runtime — no extra fix needed in this PR.

`src/db/migrations/*.sql` (only other `readFileSync` runtime path) live under `src/` which is always copied. Not affected.

## Notes for reviewer

- The cascading pattern (`docs/`, `!docs/`, `docs/*`, `!docs/contracts/`, `docs/contracts/*`, `!docs/contracts/pipeline-def.schema.json`) is the form Docker explicitly documents for re-including a child of an excluded parent. Without each layer, BuildKit short-circuits at the first matching exclude.
- Image size impact: +5421 bytes (one JSON file). No fixtures included.
- No test changes — the failure is filesystem packaging, not behaviour. The existing `loadPipelineDefSchema` unit tests already exercise the parser; CI's docker build smoke would catch a regression here.