### PR TITLE
fix(boot): wire SQLite DB into main() so publisher routes mount

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { readMurmurTokenFromEnv } from "./index.js";
+import { readDatabasePathFromEnv, readMurmurTokenFromEnv } from "./index.js";
 
 /**
  * Path to `src/index.ts`, computed relative to this test file. Used by the
@@ -75,6 +75,26 @@ describe("readMurmurTokenFromEnv", () => {
     expect(() =>
       readMurmurTokenFromEnv({ MURMUR_TOKEN: "" } as NodeJS.ProcessEnv),
     ).toThrow(/MURMUR_TOKEN/);
+  });
+});
+
+describe("readDatabasePathFromEnv", () => {
+  it("returns the path when DATABASE_PATH is set", () => {
+    expect(
+      readDatabasePathFromEnv({
+        DATABASE_PATH: "/mnt/murmur/murmur.db",
+      } as NodeJS.ProcessEnv),
+    ).toBe("/mnt/murmur/murmur.db");
+  });
+
+  it("returns undefined when DATABASE_PATH is absent (smoke-image mode)", () => {
+    expect(readDatabasePathFromEnv({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  it("throws referencing DATABASE_PATH when set to empty string", () => {
+    expect(() =>
+      readDatabasePathFromEnv({ DATABASE_PATH: "" } as NodeJS.ProcessEnv),
+    ).toThrow(/DATABASE_PATH/);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import { serve, type ServerType } from "@hono/node-server";
 
 import type Database from "better-sqlite3";
 
+import { openDb } from "./db/index.js";
+import { runMigrations } from "./db/migrate.js";
 import { log } from "./logger.js";
 import { createServer } from "./server.js";
 import { ClaimSweeper } from "./sweeper.js";
@@ -99,6 +101,34 @@ export function readMurmurTokenFromEnv(env: NodeJS.ProcessEnv): Buffer {
   return Buffer.from(raw, "utf8");
 }
 
+/**
+ * Read `DATABASE_PATH` from a `process.env`-shaped object.
+ *
+ * @returns the path as a non-empty string, or `undefined` when the var is
+ *   absent. An absent var is treated as "no DB" so the bare-bones smoke
+ *   image (health-only) still boots — the publisher and agent sub-apps
+ *   simply do not mount in that case.
+ * @throws Error if the var is set to the empty string (operator typo —
+ *   fail fast rather than silently disable the publisher routes).
+ *
+ * Pure function (takes `env` as input rather than reading `process.env`
+ * directly) so unit tests can exercise the parsing without mutating the
+ * host process's environment.
+ */
+export function readDatabasePathFromEnv(
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const raw = env.DATABASE_PATH;
+  if (raw === undefined) return undefined;
+  if (raw === "") {
+    throw new Error(
+      "DATABASE_PATH environment variable must be a non-empty filesystem path " +
+        "(or absent to run health-only). Got empty string.",
+    );
+  }
+  return raw;
+}
+
 export interface ServerHandle {
   close(): Promise<void>;
 }
@@ -168,8 +198,26 @@ export function startServer(
 export async function main(): Promise<ServerHandle> {
   const port = readPortFromEnv(process.env);
   const token = readMurmurTokenFromEnv(process.env);
-  const handle = startServer(port, token);
-  log.info("server.listening", { port });
+  const dbPath = readDatabasePathFromEnv(process.env);
+
+  // Open the SQLite handle and run forward-only migrations BEFORE binding
+  // the port. The publisher/agent routes assume the schema is already in
+  // place (see `createServer` JSDoc). Doing this synchronously up-front
+  // means the server only starts answering requests once the DB is ready;
+  // `process.exit(1)` on any failure keeps a half-migrated boot from
+  // serving 5xxs forever.
+  let db: Database.Database | undefined;
+  if (dbPath !== undefined) {
+    db = openDb(dbPath);
+    const result = runMigrations(db);
+    log.info("db.migrations_applied", {
+      applied: result.applied.length,
+      skipped: result.skipped.length,
+    });
+  }
+
+  const handle = startServer(port, token, db);
+  log.info("server.listening", { port, db: dbPath !== undefined });
   return handle;
 }
 


### PR DESCRIPTION
## Problem

Discovered while attempting to register the `jobseek-add-company` pipeline against prod murmur — `POST /pipelines` returned **404**.

Inspection of `src/index.ts#main()`:

```ts
export async function main(): Promise<ServerHandle> {
  const port = readPortFromEnv(process.env);
  const token = readMurmurTokenFromEnv(process.env);
  const handle = startServer(port, token);   // ⟵ no `db` arg
  ...
}
```

Per `createServer.options.db` JSDoc, when `db` is omitted the publisher (`POST /pipelines`, `POST /pipelines/{id}/runs`, `GET /runs/{run_id}`) and agent (`GET /work/next`, `POST /work/{claim_token}/result`) sub-apps are **not mounted**, and the claim sweeper is not started. So the deployed murmur was running health-only and could not serve any demo traffic.

`DATABASE_PATH` is already set in `docker-compose.yml`:
```yaml
DATABASE_PATH: ${DATABASE_PATH:-/mnt/murmur/murmur.db}
```
The volume + env are in place; the boot module just never read the var.

## Fix

- New `readDatabasePathFromEnv(env)` helper, parallel shape to `readPort` / `readMurmurToken`. Returns `undefined` when unset (smoke-image mode), throws on empty string (operator typo).
- `main()` opens the DB, runs `runMigrations`, passes it to `startServer`. Done before binding the port so the server only starts answering once the schema is in place.

## Test plan

- [x] `readDatabasePathFromEnv` unit tests (set / unset / empty)
- [x] `pnpm typecheck` clean
- [x] `pnpm exec eslint src/index.ts src/index.test.ts` clean
- [ ] On merge: prod murmur restarts with publisher routes mounted; `POST /pipelines` returns 200/4xx (not 404)
- [ ] `tsx apps/crawler/murmur/scripts/register.ts apps/crawler/murmur/pipelines/add-company.yaml` succeeds end-to-end against `https://murmur.colophon-group.org`
- [ ] `POST /api/admin/murmur-demo/run` triggers a run that progresses past pre-verify

## Why merge ASAP

Without this, the demo cannot run — Murmur's sole role in the demo is to dispatch the pipeline, and the registration endpoint is unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)