### PR TITLE
fix(webhook): bump default per-attempt timeout from 15s to 60s

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -58,10 +58,15 @@ export const DEFAULT_WEBHOOK_RETRY_DELAY_MS = 30 * 1000;
 
 /**
  * Default per-attempt HTTP timeout. The publisher should ack quickly;
- * a slow webhook receiver eats throughput. 15s matches the dispatcher's
- * publisher-call timeout in M7.
+ * a slow webhook receiver eats throughput. The accept handler in
+ * jobseek-murmur-shim does a defense-in-depth `rerunProbes` step that
+ * spawns one Python subprocess per board (Playwright + httpx + crawler
+ * tree on a cold venv); empirically that takes ~20s for a 1-board run,
+ * which busts the original 15s budget. 60s gives ~3x headroom and
+ * still keeps a misbehaving receiver from holding murmur's delivery
+ * worker for very long.
  */
-export const DEFAULT_WEBHOOK_REQUEST_TIMEOUT_MS = 15 * 1000;
+export const DEFAULT_WEBHOOK_REQUEST_TIMEOUT_MS = 60 * 1000;
 
 /**
  * Minimal HTTP-response shape this module needs. Defined locally so


### PR DESCRIPTION
## Summary

The jobseek-murmur-shim's accept handler runs a defense-in-depth `rerunProbes` step that spawns one Python subprocess per board (Playwright + httpx + the entire crawler tree on a cold venv). For a 1-board run this empirically takes ~20s, which busts the 15s `DEFAULT_WEBHOOK_REQUEST_TIMEOUT_MS`.

Result: every webhook delivery times out with `"This operation was aborted"`. Both retry attempts hit the same wall, webhook_status flips to `failed`, and the demo run never visibly publishes — even though the receiver is happily writing the catalog row server-side.

## Live evidence (prod)

Run `r_b33a598674192a29cf6d0eb7` (Discord):

- Manual POST to `https://jobseek.colophon-group.org/api/murmur/accept` with the run's composed `final_output`: `{ok:true, applied:true, company_id:..., board_count:1}` in **22.6s**
- Murmur's deliver attempts: both logged `webhook.attempt_transport_error error:"This operation was aborted"` after the 15s race timer expired

## Fix

Bump default to 60s — ~3x headroom over the observed worst case, still well under the agent claim TTL so a runaway receiver can't lock anything for too long.

The constant is already env-overridable via the route-level seam, so callers (and tests) that want a tighter bound keep the option.

## Test plan

- [x] `src/webhook.test.ts` — all 13 tests pass
- [ ] After deploy + a fresh demo run: webhook fires, `webhook_status` flips to `delivered`, the company row appears in jobseek's catalog table on local Hetzner Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)