### PR TITLE
docs(design): retire legacy {accepted} envelope wording from §3.4 (#40)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -298,7 +298,7 @@ No retries on schema-validation failure for MVP — the run fails.
 Three static tools, fixed for the lifetime of the connection:
 
 - `pull_task({ run_id?: string })` → `{ instructions, input, output_schema, claim }` or `null`. `run_id` is optional; when supplied, the claim is restricted to ready subtasks of that run (issue #75 — drives a single run end-to-end without picking up unrelated queued work). Forwards to `GET /work/next?run_id=…`.
-- `submit_result(claim, result, notes?)` → `{ accepted: true } | { accepted: false, errors: [...] }`. `notes` is an optional free-text reflection persisted in the audit log alongside the structured `result`.
+- `submit_result(claim, result, notes?)` → the canonical response envelope `{ ok, errors?, data? }` per `docs/contracts.md` §4. Validation failures use the `validation:<path>:<message>` token form per §4.4. `notes` is an optional free-text reflection persisted in the audit log alongside the structured `result`. (The legacy `{ accepted: true | false, errors }` shape this section described pre-#38 has been retired — every agent endpoint uses the single envelope; `grep:no-accepted-key` enforces the absence in CI.)
 - `task_tool(subcommand: string, claim: string, args?: object)` → `string | object` — universal dispatcher. Invokes a publisher-declared subcommand for a claim (see §3.1). `claim` is required (no session-based fallback in MVP). Static description (visible to the host's tool catalog):
 
   > *Invoke a subcommand for the current claim. The subtask `instructions` will tell you which subcommands to use and when; `task_tool('<name>', '<claim>', {...})` invokes one. The `claim` value is what `pull_task` returned in its `claim` field.*

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -241,9 +241,8 @@ There is no `{ "accepted": true, ... }` parallel envelope. The
 `grep:no-accepted-key` gate fails CI if `\baccepted:\s` appears in source
 or test files outside `_legacy/`. The gate covers TS/JS file extensions
 under `src/`, `packages/*/src/`, `apps/*/src/`, and the matching `test/`
-trees. (DESIGN.md §3.4 mentions `{ accepted: true | false }` for the
-old `submit_result` shape; that text is **superseded by this contract**
-and will be reconciled when DESIGN.md is next revised.)
+trees. (DESIGN.md §3.4 was reconciled in #40 — the `submit_result`
+description there now points at this section as authoritative.)
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #40. \`DESIGN.md\` §3.4 still described \`submit_result\` as
returning \`{ accepted: true } | { accepted: false, errors: [...] }\`.
PR #38 landed the canonical \`{ ok, errors?, data? }\` envelope as the
single shape for every agent endpoint (\`docs/contracts.md\` §4 + §4.4);
the \`grep:no-accepted-key\` gate enforces the absence of the legacy
form in source / test files. The two docs disagreed.

This PR updates §3.4 to point at \`docs/contracts.md\` §4 / §4.4 as
authoritative + drops the "will be reconciled when DESIGN.md is next
revised" note in contracts.md §4.4 — that's exactly what this PR does.

## Test plan

- [x] \`pnpm grep:all\` passes (no \`accepted:\` literal anywhere outside
      the \`grep:no-accepted-key\` script + the negative-assertion text
      in contracts.md §4.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)